### PR TITLE
Added an HTTP Authentication Option for Heroku

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -241,6 +241,7 @@ added where your cursor was.  Binding this to a keybinding can allow you to add 
 [<tt>create</tt>] Create new showoff presentation
 [<tt>help</tt>] Shows list of commands or help for one command
 [<tt>heroku</tt>] Setup your presentation to serve on Heroku
+[<tt>heroku_secure</tt>] Setup your presentation to serve on Heroku with password protection
 [<tt>serve</tt>] Serves the showoff presentation in the current directory
 
 === <tt>add [title]</tt>
@@ -281,6 +282,10 @@ Shows list of commands or help for one command
 === <tt>heroku heroku_name</tt>
 
 Setup your presentation to serve on Heroku
+
+=== <tt>heroku_secure heroku_name password</tt>
+
+Setup your presentation to serve on Heroku with password protection using HTTP Authentication
 
 === <tt>serve </tt>
 

--- a/bin/showoff
+++ b/bin/showoff
@@ -25,6 +25,19 @@ command [:create,:init] do |c|
   end
 end
 
+desc 'Same as heroku create, but also adds password protection'
+arg_name 'heroku_name password'
+long_desc 'Creates the .gems file and config.ru file needed to push a showoff pres to heroku with password protection.  it will then run ''heroku create'' for you to register the new project on heroku and add the remote for you.  then all you need to do is commit the new created files and run ''git push heroku'' to deploy.'
+command :heroku_secure do |c|
+  c.action do |global_options,options,args|
+		p args
+    raise "heroku_name is required" if args.empty?
+    raise "password is required" if args.length == 1
+    ShowOffUtils.heroku_secure(args[0], args[1])
+  end
+end
+
+desc 'Serves the showoff presentation in the current directory'
 desc 'Setup your presentation to serve on Heroku'
 arg_name 'heroku_name'
 long_desc 'Creates the .gems file and config.ru file needed to push a showoff pres to heroku.  it will then run ''heroku create'' for you to register the new project on heroku and add the remote for you.  then all you need to do is commit the new created files and run ''git push heroku'' to deploy.'

--- a/lib/showoff_utils.rb
+++ b/lib/showoff_utils.rb
@@ -28,6 +28,7 @@ class ShowOffUtils
     end
   end
 
+	# Setup presentation to run on Heroku
   def self.heroku(name)
     if !File.exists?(SHOWOFF_JSON_FILE)
       puts "fail. not a showoff directory"
@@ -45,6 +46,42 @@ class ShowOffUtils
     File.open('config.ru', 'w+') do |f|
       f.puts 'require "showoff"'
       f.puts 'run ShowOff.new'
+    end if !File.exists?('config.ru')
+
+    puts "herokuized. run something like this to launch your heroku presentation:
+
+      heroku create #{name}
+      git add .gems config.ru
+      git commit -m 'herokuized'
+      git push heroku master
+    "
+  end
+
+	# Setup the presentation to run on Heroku with password protection
+  def self.heroku_secure(name, password)
+    if !File.exists?(SHOWOFF_JSON_FILE)
+      puts "fail. not a showoff directory"
+      return false
+    end
+    # create .gems file
+    File.open('.gems', 'w+') do |f|
+      f.puts "bluecloth"
+      f.puts "nokogiri"
+      f.puts "showoff"
+      f.puts "gli"
+      f.puts "rack"
+    end if !File.exists?('.gems')
+
+    # create config.ru file
+    File.open('config.ru', 'w+') do |f|
+      f.puts 'require "rack"'
+      f.puts 'require "showoff"'
+			f.puts 'showoff_app = ShowOff.new'
+			f.puts 'protected_showoff = Rack::Auth::Basic.new(showoff_app) do |username, password|'
+			f.puts	"\tpassword == '#{password}'"
+			f.puts 'end'
+			f.puts 'run protected_showoff'
+
     end if !File.exists?('config.ru')
 
     puts "herokuized. run something like this to launch your heroku presentation:


### PR DESCRIPTION
Not sure if this is something that you would be interested in including in the master app, but I wanted the ability to post my presentation online without letting the world have access to it. So I added a command line generator 'heroku_secure' that adds HTTP Authentication to the showoff app. I implemented this using the Rack::Auth::Basic middleware in the config.ru file. This also required added 'rack' to .gems.
