### PR TITLE
Fixed vertical alignment and title for static site generation

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -234,6 +234,7 @@ class ShowOff < Sinatra::Application
 
     def index(static=false)
       if static
+        @title = ShowOffUtils.showoff_title
         @slides = get_slides_html(static)
         @asset_path = "."
       end
@@ -348,7 +349,4 @@ class ShowOff < Sinatra::Application
       end
     end
   end
-
-
-
 end

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -58,6 +58,8 @@ function loadSlides(load_slides, prefix) {
 }
 
 function initializePresentation(prefix) {
+  $("#slides").show();
+
   //center slides offscreen
   centerSlides($('#slides > .slide'))
 


### PR DESCRIPTION
Hey there, this is two simple fixes for static site generation in showoff. I reported this in schacon#49. The vertical alignment could also be fixed by pulling in rctay's pull request.
