### PR TITLE
Confusing doc bug

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -43,7 +43,7 @@ remove sections easily.
 ShowOff is meant to be run in a ShowOff formatted repository - that means that it has a showoff.json file and a number of sections (subdirectories) with markdown files for the slides you're presenting.
 
     $ gem install showoff
-    $ git clone (showoff-repo)
+    $ git clone (showoff-repo)/example
     $ cd (showoff-repo)
     $ showoff serve
 


### PR DESCRIPTION
The README says to do

   $ gem install showoff
   $ git clone (showoff-repo)
   $ cd (showoff-repo)
   $ showoff serve

But, actually, in the third step, you need to

   $ cd (showoff-repo)/example

If you run 'showoff serve' from the (showoff-repo) top-level directory, you get a blank page with garbage slide numbers ("NaN/0 - NaN%" at the bottom).

Thanks,
Q
