### PR TITLE
Use bundler for heroku instead of .gems

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -283,12 +283,13 @@ Shows list of commands or help for one command
 
 Setup your presentation to serve on Heroku
 
-Creates the .gems file and config.ru file needed to push a showoff pres to heroku.  It will then run heroku create for you to register the new project on heroku and add the remote for you.  Then all you need to do is commit the new created files and run git push heroku to deploy.
+Creates the Gemfile and config.ru file needed to push a showoff pres to heroku.  It will then run heroku create for you to register the new project on heroku and add the remote for you.  Then all you need to do is commit the new created files and run git push heroku to deploy.
 
 ==== Options
 These options are specified *after* the command.
 
-[<tt>-f, --force</tt>] force overwrite of existing .gems and config.ru files if they exist
+[<tt>-f, --force</tt>] force overwrite of existing Gemfile/.gems and config.ru files if they exist
+[<tt>-g, --dotgems</tt>] Use older-style .gems file instead of bundler-style Gemfile
 [<tt>-p, --password=arg</tt>] add password protection to your heroku site
 === <tt>serve </tt>
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -241,8 +241,8 @@ added where your cursor was.  Binding this to a keybinding can allow you to add 
 [<tt>create</tt>] Create new showoff presentation
 [<tt>help</tt>] Shows list of commands or help for one command
 [<tt>heroku</tt>] Setup your presentation to serve on Heroku
-[<tt>heroku_secure</tt>] Setup your presentation to serve on Heroku with password protection
 [<tt>serve</tt>] Serves the showoff presentation in the current directory
+[<tt>static</tt>] Generate static version of presentation
 
 === <tt>add [title]</tt>
 
@@ -283,19 +283,27 @@ Shows list of commands or help for one command
 
 Setup your presentation to serve on Heroku
 
-=== <tt>heroku_secure heroku_name password</tt>
+Creates the .gems file and config.ru file needed to push a showoff pres to heroku.  It will then run heroku create for you to register the new project on heroku and add the remote for you.  Then all you need to do is commit the new created files and run git push heroku to deploy.
 
-Setup your presentation to serve on Heroku with password protection using HTTP Authentication
+==== Options
+These options are specified *after* the command.
 
+[<tt>-f, --force</tt>] force overwrite of existing .gems and config.ru files if they exist
+[<tt>-p, --password=arg</tt>] add password protection to your heroku site
 === <tt>serve </tt>
 
 Serves the showoff presentation in the current directory
 
 
+
 ==== Options
 These options are specified *after* the command.
 
+[<tt>-h, --host=arg</tt>] Host or ip to run on <i>( default: <tt>localhost</tt>)</i>
 [<tt>-p, --port=arg</tt>] Port on which to run <i>( default: <tt>9090</tt>)</i>
+=== <tt>static name</tt>
+
+Generate static version of presentation
 
 === ZSH completion
 You can complete commands and options in ZSH, by installing a script:

--- a/bin/showoff
+++ b/bin/showoff
@@ -28,18 +28,21 @@ end
 desc 'Serves the showoff presentation in the current directory'
 desc 'Setup your presentation to serve on Heroku'
 arg_name 'heroku_name'
-long_desc 'Creates the .gems file and config.ru file needed to push a showoff pres to heroku.  It will then run ''heroku create'' for you to register the new project on heroku and add the remote for you.  Then all you need to do is commit the new created files and run ''git push heroku'' to deploy.'
+long_desc 'Creates the Gemfile and config.ru file needed to push a showoff pres to heroku.  It will then run ''heroku create'' for you to register the new project on heroku and add the remote for you.  Then all you need to do is commit the new created files and run ''git push heroku'' to deploy.'
 command :heroku do |c|
 
   c.desc 'add password protection to your heroku site'
   c.flag [:p,:password]
 
-  c.desc 'force overwrite of existing .gems and config.ru files if they exist'
+  c.desc 'force overwrite of existing Gemfile/.gems and config.ru files if they exist'
   c.switch [:f,:force]
+
+  c.desc 'Use older-style .gems file instead of bundler-style Gemfile'
+  c.switch [:g,:dotgems]
 
   c.action do |global_options,options,args|
     raise "heroku_name is required" if args.empty?
-    ShowOffUtils.heroku(args[0],options[:f],options[:p])
+    ShowOffUtils.heroku(args[0],options[:f],options[:p],options[:g])
   end
 end
 

--- a/bin/showoff
+++ b/bin/showoff
@@ -25,26 +25,18 @@ command [:create,:init] do |c|
   end
 end
 
-desc 'Same as heroku create, but also adds password protection'
-arg_name 'heroku_name password'
-long_desc 'Creates the .gems file and config.ru file needed to push a showoff pres to heroku with password protection.  it will then run ''heroku create'' for you to register the new project on heroku and add the remote for you.  then all you need to do is commit the new created files and run ''git push heroku'' to deploy.'
-command :heroku_secure do |c|
-  c.action do |global_options,options,args|
-		p args
-    raise "heroku_name is required" if args.empty?
-    raise "password is required" if args.length == 1
-    ShowOffUtils.heroku_secure(args[0], args[1])
-  end
-end
-
 desc 'Serves the showoff presentation in the current directory'
 desc 'Setup your presentation to serve on Heroku'
 arg_name 'heroku_name'
-long_desc 'Creates the .gems file and config.ru file needed to push a showoff pres to heroku.  it will then run ''heroku create'' for you to register the new project on heroku and add the remote for you.  then all you need to do is commit the new created files and run ''git push heroku'' to deploy.'
+long_desc 'Creates the .gems file and config.ru file needed to push a showoff pres to heroku.  It will then run ''heroku create'' for you to register the new project on heroku and add the remote for you.  Then all you need to do is commit the new created files and run ''git push heroku'' to deploy.'
 command :heroku do |c|
+
+  c.desc 'add password protection to your heroku site'
+  c.flag [:p,:password]
+
   c.action do |global_options,options,args|
     raise "heroku_name is required" if args.empty?
-    ShowOffUtils.heroku(args[0])
+    ShowOffUtils.heroku(args[0], options[:p])
   end
 end
 

--- a/bin/showoff
+++ b/bin/showoff
@@ -34,9 +34,12 @@ command :heroku do |c|
   c.desc 'add password protection to your heroku site'
   c.flag [:p,:password]
 
+  c.desc 'force overwrite of existing .gems and config.ru files if they exist'
+  c.switch [:f,:force]
+
   c.action do |global_options,options,args|
     raise "heroku_name is required" if args.empty?
-    ShowOffUtils.heroku(args[0], options[:p])
+    ShowOffUtils.heroku(args[0],options[:f],options[:p])
   end
 end
 

--- a/lib/showoff_utils.rb
+++ b/lib/showoff_utils.rb
@@ -29,7 +29,10 @@ class ShowOffUtils
   end
 
 	# Setup presentation to run on Heroku
-  def self.heroku(name)
+  #
+  # name - String containing herokku name
+  # password - String containing password to protect your heroku site; nil means no password protection
+  def self.heroku(name,password=nil)
     if !File.exists?(SHOWOFF_JSON_FILE)
       puts "fail. not a showoff directory"
       return false
@@ -40,48 +43,22 @@ class ShowOffUtils
       f.puts "nokogiri"
       f.puts "showoff"
       f.puts "gli"
+      f.puts "rack" unless password.nil?
     end if !File.exists?('.gems')
 
     # create config.ru file
     File.open('config.ru', 'w+') do |f|
       f.puts 'require "showoff"'
-      f.puts 'run ShowOff.new'
-    end if !File.exists?('config.ru')
-
-    puts "herokuized. run something like this to launch your heroku presentation:
-
-      heroku create #{name}
-      git add .gems config.ru
-      git commit -m 'herokuized'
-      git push heroku master
-    "
-  end
-
-	# Setup the presentation to run on Heroku with password protection
-  def self.heroku_secure(name, password)
-    if !File.exists?(SHOWOFF_JSON_FILE)
-      puts "fail. not a showoff directory"
-      return false
-    end
-    # create .gems file
-    File.open('.gems', 'w+') do |f|
-      f.puts "bluecloth"
-      f.puts "nokogiri"
-      f.puts "showoff"
-      f.puts "gli"
-      f.puts "rack"
-    end if !File.exists?('.gems')
-
-    # create config.ru file
-    File.open('config.ru', 'w+') do |f|
-      f.puts 'require "rack"'
-      f.puts 'require "showoff"'
-			f.puts 'showoff_app = ShowOff.new'
-			f.puts 'protected_showoff = Rack::Auth::Basic.new(showoff_app) do |username, password|'
-			f.puts	"\tpassword == '#{password}'"
-			f.puts 'end'
-			f.puts 'run protected_showoff'
-
+      if password.nil?
+        f.puts 'run ShowOff.new'
+      else
+        f.puts 'require "rack"'
+        f.puts 'showoff_app = ShowOff.new'
+        f.puts 'protected_showoff = Rack::Auth::Basic.new(showoff_app) do |username, password|'
+        f.puts	"\tpassword == '#{password}'"
+        f.puts 'end'
+        f.puts 'run protected_showoff'
+      end
     end if !File.exists?('config.ru')
 
     puts "herokuized. run something like this to launch your heroku presentation:


### PR DESCRIPTION
Heroku has switched to bundler as the canonical gem management, so this patch makes that change by generating a properly-formatted Gemfile.

The old method is still available via `-g` to the `heroku` command.

Note that this applies against this pull request: https://github.com/schacon/showoff/pull/56  which is a rework/simplification of the `heroku` and `heroku_secure` commands.

Here's the example presentation running on heroku using bundler: http://showoff-uses-bundler.heroku.com/
