### PR TITLE
Copy all needed js/css/image files to static dir

### DIFF
--- a/bin/showoff
+++ b/bin/showoff
@@ -30,7 +30,6 @@ arg_name 'heroku_name password'
 long_desc 'Creates the .gems file and config.ru file needed to push a showoff pres to heroku with password protection.  it will then run ''heroku create'' for you to register the new project on heroku and add the remote for you.  then all you need to do is commit the new created files and run ''git push heroku'' to deploy.'
 command :heroku_secure do |c|
   c.action do |global_options,options,args|
-		p args
     raise "heroku_name is required" if args.empty?
     raise "password is required" if args.length == 1
     ShowOffUtils.heroku_secure(args[0], args[1])

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -9,13 +9,13 @@ require 'fileutils'
 begin
   require 'RMagick'
 rescue LoadError
-  puts 'image sizing disabled - install RMagick'
+  $stderr.puts 'image sizing disabled - install RMagick'
 end
 
 begin
   require 'princely'
 rescue LoadError
-  puts 'pdf generation disabled - install princely'
+  $stderr.puts 'pdf generation disabled - install princely'
 end
 
 begin

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -125,7 +125,7 @@ class ShowOff < Sinatra::Application
       paths.pop
       path = paths.join('/')
       replacement_prefix = static ?
-        %(img src="file://#{options.pres_dir}/#{path}) :
+        %(img src="./file/#{path}) :
         %(img src="/image/#{path})
       slide.gsub(/img src=\"(.*?)\"/) do |s|
         img_path = File.join(path, $1)
@@ -237,7 +237,7 @@ class ShowOff < Sinatra::Application
       if static
         @title = ShowOffUtils.showoff_title
         @slides = get_slides_html(static)
-        @asset_path = "."
+        @asset_path = "./"
       end
       erb :index
     end
@@ -317,7 +317,7 @@ class ShowOff < Sinatra::Application
       else
         out  = "#{path}/#{name}/static"
         # First make a directory
-        FileUtils.makedirs("#{out}")
+        FileUtils.makedirs(out)
         # Then write the html
         file = File.new("#{out}/index.html", "w")
         file.puts(data)
@@ -334,6 +334,23 @@ class ShowOff < Sinatra::Application
           next unless File.directory?(subpath) || base.match(/\.(css|js)$/)
           FileUtils.copy_entry(subpath, "#{out}/#{base}")
         }
+
+        # Set up file dir
+        file_dir = File.join(out, 'file')
+        FileUtils.makedirs(file_dir)
+        pres_dir = showoff.options.pres_dir
+
+        # ..., copy all user-defined styles and javascript files
+        Dir.glob("#{pres_dir}/*.{css,js}").each { |path|
+          FileUtils.copy(path, File.join(file_dir, File.basename(path)))
+        }
+
+        # ... and copy all needed image files
+        data.scan(/img src=\".\/file\/(.*?)\"/).flatten.each do |path|
+          dir = File.dirname(path)
+          FileUtils.makedirs(File.join(file_dir, dir))
+          FileUtils.copy(File.join(pres_dir, path), File.join(file_dir, path))
+        end
       end
     end
 

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -269,14 +269,14 @@ class ShowOff < Sinatra::Application
         href = clean_link(link['src'])
         assets << href if href
       end
-      
+
       css = Dir.glob("#{options.public}/**/*.css").map { |path| path.gsub(options.public + '/', '') }
       assets << css
 
       js = Dir.glob("#{options.public}/**/*.js").map { |path| path.gsub(options.public + '/', '') }
       assets << js
 
-      assets.uniq.join("\n")      
+      assets.uniq.join("\n")
     end
 
     def slides(static=false)


### PR DESCRIPTION
`showoff static` now produces a real, ready-to-run-everywhere presentation.
I needed this for two presentations and it really bugged me to fix the paths manually.

With this patch you can take the _static_ dir, drop it on a usb stick and show the presentation on whatever computer is near including all images, custom styles and javascript code you wrote.
