### PR TITLE
Alternate means of showing version is CLI

### DIFF
--- a/bin/showoff
+++ b/bin/showoff
@@ -7,13 +7,7 @@ require 'gli'
 
 include GLI
 
-desc 'Show ShowOff version'
-long_desc 'This command shows the currently installed version of ShowOff'
-command [:version] do |c|
-  c.action do |global_options,options,args|
-    puts "ShowOff Version " + ShowOff::Version
-  end
-end
+version ShowOff::Version 
 
 desc 'Create new showoff presentation'
 arg_name 'dir_name'
@@ -139,4 +133,4 @@ on_error do |exception|
   true
 end
 
-GLI.run(ARGV)
+exit GLI.run(ARGV)

--- a/showoff.gemspec
+++ b/showoff.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency      "bluecloth"
   s.add_dependency      "nokogiri"
   s.add_dependency      "json"
-  s.add_dependency      ("gli",">= 1.1.1")
+  s.add_dependency      ("gli",">= 1.2.5")
   s.description       = <<-desc
   ShowOff is a Sinatra web app that reads simple configuration files for a
   presentation.  It is sort of like a Keynote web app engine.  I am using it


### PR DESCRIPTION
GLI 1.2.5 adds the `version` directive that does _mostly_ what the `:version` command does; essentially shows the showoff version in the output of `showoff help`.
