### PR TITLE
Squelch markdown warning

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -9,19 +9,20 @@ require 'fileutils'
 begin
   require 'RMagick'
 rescue LoadError
-  $stderr.puts 'image sizing disabled - install RMagick'
+  $stderr.puts 'image sizing disabled - install rmagick'
 end
 
 begin
   require 'pdfkit'
 rescue LoadError
-  $stderr.puts 'pdf generation disabled - install PDFKit'
+  $stderr.puts 'pdf generation disabled - install pdfkit'
 end
 
 begin
   require 'rdiscount'
 rescue LoadError
   require 'bluecloth'
+  Object.send(:remove_const,:Markdown)
   Markdown = BlueCloth
 end
 require 'pp'


### PR DESCRIPTION
Not sure if I'm the only one getting this, but I get the `./bin/../lib/showoff.rb:25: warning: already initialized constant Markdown` every time.  Used `remove_const` to remove the constant before reassigning it.

Also changed the names of the packages in the warnings to the names of the gems to install (e.g. `rmagick` instead of `RMagick`)
