### PR TITLE
Slide sizing updates

### DIFF
--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -1,24 +1,41 @@
 @media screen {
   body {
       font-family: "Gill Sans", Helvetica, Arial, sans-serif;
+      background:#333;
+      overflow:hidden;
+      margin:0;
+      padding:0;
   }
 
   #preso, .slide {
       background: #fff;
-      width: 1020px;
-      height: 740px;
+      width: 1024px;
+      height: 768px;
       margin-left:auto;
       margin-right:auto;
       overflow:hidden;
+      -webkit-box-shadow:0 0 25px rgba(0,0,0,0.35);
+      -moz-box-shadow:0 0 25px rgba(0,0,0,0.35);
+      box-shadow:0 0 25px rgba(0,0,0,0.35);
   }
 
   #footer {
-      background: #eee;
-      padding: 2px;
-      width: 1010px;
+      background: rgba(221,221,221,0.75);
+      color:#333;
+      padding: 2px 5px;
+      width: 1005px;
       height: 20px;
-      margin-left:auto;
-      margin-right:auto;
+      line-height:20px;
+      font-size:14px;
+      position:relative;
+      top:-24px;
+      margin:0 auto;
+      -webkit-border-top-left-radius: 3px;
+      -webkit-border-top-right-radius: 3px;
+      -moz-border-radius-topleft: 3px;
+      -moz-border-radius-topright: 3px;
+      border-top-left-radius: 3px;
+      border-top-right-radius: 3px;
   }
 }
 
@@ -26,49 +43,45 @@
 /* Portrait */
 @media screen and (max-width: 320px)
 {
-  #preso { 
+  #preso {
       margin: 0;
       padding: 0;
       width: 320px;
       max-height: 356px;
-      margin-left:auto; 
+      margin-left:auto;
       margin-right:auto;
 /*      overflow:hidden;*/
   }
-  #footer { 
+  #footer {
       background: #eee;
       margin: 0;
       padding: 2px;
       width: 320px;
       height: 20px;
-      margin-left:auto; 
+      margin-left:auto;
       margin-right:auto;
   }
 }
 /* Landscape */
 @media screen and (max-width: 480px)
 {
-  #preso { 
+  #preso {
       margin: 0;
       padding: 0;
 /*      min-height: 320px;*/
       width: 480px;
-      margin-left:auto; 
+      margin-left:auto;
       margin-right:auto;
   }
-  #footer { 
+  #footer {
       background: #eee;
       margin: 0;
       padding: 2px;
       width: 480px;
       height: 20px;
-      margin-left:auto; 
+      margin-left:auto;
       margin-right:auto;
   }
-}
-
-.slide {
-    border: 1px solid #fff;
 }
 
 .center img {
@@ -287,11 +300,11 @@ a.fg-button { float:left; }
   body {
     font-size: 70%;
   }
-  
+
   #preso, .slide {
     border: 1px solid #999;
   }
-  
+
   .slide .center {
     width: 600px;
     height: 600px;
@@ -299,7 +312,7 @@ a.fg-button { float:left; }
     text-align: center;
     vertical-align: middle;
   }
-  
+
   #preso, .slide {
       background: #fff;
       width: 600px;
@@ -317,7 +330,7 @@ a.fg-button { float:left; }
       margin-left:auto;
       margin-right:auto;
   }
-  
+
   pre, code {
     font-family: Monaco, monospace;
   }

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -190,8 +190,6 @@ function showSlide(back_step) {
 	if (fullPage) {
 		$('#preso').css({'width' : '100%', 'overflow' : 'visible'});
 		currentSlide.css({'width' : '100%', 'text-align' : 'center', 'overflow' : 'visible'});
-	} else {
-		$('#preso').css({'width' : '1020px', 'overflow' : 'hidden'});
 	}
 
 	percent = getSlidePercent()


### PR DESCRIPTION
This patch improves the slide sizing a bit to help with custom theming.
1. Slides are now 1024x768 (so you can style the space where the footer is/used to be if you hide it)
2. Scrollbars are now impossible to achieve
3. Added some default styling to the development view (not fullscreen) to make it clearer where the edges of the presentation lay (see screenshot)

![](http://share.kyleneath.com/captures/Documentation_is_freaking_awesome-20110116-201225.png)
