### PR TITLE
Pdf fix images

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -346,6 +346,10 @@ These options are specified *after* the command.
 
 Generate static version of presentation
 
+=== PDF
+Append a "/pdf" to the end of your presentation URL, and a PDF will be generated within the browser. For example,
+http://localhost:9090/pdf
+
 === ZSH completion
 You can complete commands and options in ZSH, by installing a script:
 

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -127,7 +127,7 @@ class ShowOff < Sinatra::Application
       paths.pop
       path = paths.join('/')
       replacement_prefix = static ?
-        %(img src="./file/#{path}) :
+        %(img src="file://#{options.pres_dir}/#{path}) :
         %(img src="/image/#{path})
       slide.gsub(/img src=\"(.*?)\"/) do |s|
         img_path = File.join(path, $1)


### PR DESCRIPTION
Images in generated PDF file were broken, this seems to fix it. Tested on Snow Leopard with Chrome and FireFox. Tested example preso normally, generated PDF at http://localhost:9090/pdf, and "showoff static" command.
