### PR TITLE
Allow any case for lang attr

### DIFF
--- a/example/two/slidesA.md
+++ b/example/two/slidesA.md
@@ -22,7 +22,7 @@
 
 # Executable JavaScript #
 
-	@@@ javaScript
+	@@@ javascript
 	result = 3 + 3;
 
 !SLIDE

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -162,7 +162,7 @@ class ShowOff < Sinatra::Application
           lines = out.split("\n")
           if lines.first[0, 3] == '@@@'
             lang = lines.shift.gsub('@@@', '').strip
-            pre.set_attribute('class', 'sh_' + lang)
+            pre.set_attribute('class', 'sh_' + lang.downcase)
             code.content = lines.join("\n")
           end
         end

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -320,7 +320,7 @@ function keyDown(event)
 			gotoSlidenum = 0;
 		} else {
 			debug('executeCode');
-			executeCode.call($('.sh_javaScript code:visible'));
+			executeCode.call($('.sh_javascript code:visible'));
 		}
 
 	}
@@ -465,7 +465,7 @@ function executeCode () {
 	setTimeout(function() { codeDiv.removeClass("executing");}, 250 );
 	if (result != null) print(result);
 }
-$('.sh_javaScript code').live("click", executeCode);
+$('.sh_javascript code').live("click", executeCode);
 
 
 /********************


### PR DESCRIPTION
I keep typing @@@javascript in my presentations, so I changed the code to downcase
the value entered after the code prefix. I also changed showoff.js to allow the code to be
executable after this change.
