### PR TITLE
Add tap to advance slides, timer prevents from advancing too far.

### DIFF
--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -205,9 +205,11 @@ function showSlide(back_step) {
 	}
 	location.hash = slidenum + 1;
 	$('body').addSwipeEvents().
-		bind('swipeleft',	swipeLeft).
-		bind('swiperight', swipeRight)
-	removeResults()
+		bind('tap', swipeLeft).         // next
+		bind('swipeleft', swipeLeft).   // next
+		bind('swiperight', swipeRight); // prev
+
+	removeResults();
 
 	$(currentSlide).find(".content").trigger("showoff:show");
 
@@ -393,12 +395,22 @@ function keyUp(event) {
 }
 
 
+var lastSwipeLeft = (+new Date());
+var lastSwipeRight = (+new Date());
 function swipeLeft() {
-	nextStep()
+  var time = (+new Date());
+  if((time - lastSwipeLeft) > 100) {
+    lastSwipeLeft = time;
+    nextStep();
+  }
 }
 
 function swipeRight() {
-	prevStep()
+  var time = (+new Date());
+  if((time - lastSwipeRight) > 100) {
+    lastSwipeRight = time;
+    prevStep();
+  }
 }
 
 function ListMenu(s)


### PR DESCRIPTION
Added a binding to the tap event and extended the swiperight/swipeleft functions to prevent execution within a small time boundary. This way it's executed only once, even on a long swipe. Works just fine on my Nexus One with the example preso.

Closes #57 and #62

(replaces pull-request #65)
