### PR TITLE
only .execute code should be executable

### DIFF
--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -334,11 +334,11 @@ function keyDown(event)
 			gotoSlidenum = 0;
 		} else {
 			debug('executeCode');
-            var $jsCode = $('.sh_javascript code:visible')
+            var $jsCode = $('.execute .sh_javascript code:visible')
             if ($jsCode.length > 0) {
                 executeCode.call($jsCode);
             } 
-            var $rubyCode = $('.sh_ruby code:visible')
+            var $rubyCode = $('.execute .sh_ruby code:visible')
             if ($rubyCode.length > 0) {
                 executeRuby.call($rubyCode);
             }
@@ -490,7 +490,7 @@ function executeCode () {
 	setTimeout(function() { codeDiv.removeClass("executing");}, 250 );
 	if (result != null) print(result);
 }
-$('.sh_javascript code').live("click", executeCode);
+$('.execute .sh_javascript code').live("click", executeCode);
 
 function executeRuby () {
 	var codeDiv = $(this);
@@ -500,7 +500,7 @@ function executeRuby () {
         codeDiv.removeClass("executing");
     });
 }
-$('.sh_ruby code').live("click", executeRuby);
+$('.execute .sh_ruby code').live("click", executeRuby);
 
 
 /********************


### PR DESCRIPTION
With this commit it is only possible to execute code that is explicitly marked execute
as per the documentation.
I found myself clicking on code by mistake and it lit up in a distracting way.
