### PR TITLE
fix showoff:loaded event 

### DIFF
--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -86,7 +86,7 @@ function initializePresentation(prefix) {
 	}
 	setupSlideParamsCheck();
 	sh_highlightDocument(prefix+'/js/sh_lang/', '.min.js')
-	$(".preso").trigger("showoff:loaded");
+	$("#preso").trigger("showoff:loaded");
 }
 
 function centerSlides(slides) {


### PR DESCRIPTION
The showoff:loaded event was being triggered only on the nonexisting .preso div, making it difficult to write scripts.
