### PR TITLE
Fixed image sizes for SVGs so they can expand to fill their container.

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -152,7 +152,12 @@ class ShowOff < Sinatra::Application
       def get_image_size(path)
         if !cached_image_size.key?(path)
           img = Magick::Image.ping(path).first
-          cached_image_size[path] = [img.columns, img.rows]
+          # don't set a size for svgs so they can expand to fit their container
+          if img.mime_type == 'image/svg+xml'
+            cached_image_size[path] = [nil, nil]
+          else
+            cached_image_size[path] = [img.columns, img.rows]
+          end
         end
         cached_image_size[path]
       end


### PR DESCRIPTION
(Made a new pull request from a topic branch as mentioned in your Markdown documentation)

This actually works in showoff if you have SVG images that have no "height" or "width" attributes specified. You also might need to fix the SVG file so it has a proper viewbox.

I used a modified version of "scour" to fix my SVG files after exporting them from Omnigraffle:
http://www.codedread.com/scour/

You can test my changes to showoff with my showoff presentation, SVGs included:
https://github.com/nhooey/showoff-solr-intro

Now your pixelitus can be cured!
