### PR TITLE
Fixes issue #100 via an updated dep to GLI

### DIFF
--- a/showoff.gemspec
+++ b/showoff.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency      "bluecloth"
   s.add_dependency      "nokogiri"
   s.add_dependency      "json"
-  s.add_dependency("gli",">= 1.2.5")
+  s.add_dependency("gli",">= 1.3.2")
   s.add_development_dependency "mg"
   s.description       = <<-desc
   ShowOff is a Sinatra web app that reads simple configuration files for a


### PR DESCRIPTION
GLI was eating error messages produced via `raise "Houston, we have a problem"`.  1.3.2, just released, fixes this issue.

Since showoff doesn't have a test suite, I ran through creating a new slideshow, and also the example, and things seem to work OK.
