### PR TITLE
Prevent bouncing and improve swipe on iPad

### DIFF
--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -40,6 +40,11 @@ function setupPreso(load_slides, prefix) {
 	/* window.onresize	= resized; */
 	/* window.onscroll = scrolled; */
 	/* window.onunload = unloaded; */
+
+	$('body').addSwipeEvents().
+		bind('tap', swipeLeft).         // next
+		bind('swipeleft', swipeLeft).   // next
+		bind('swiperight', swipeRight); // prev
 }
 
 function loadSlides(load_slides, prefix) {
@@ -204,10 +209,6 @@ function showSlide(back_step) {
 		incrSteps = 0
 	}
 	location.hash = slidenum + 1;
-	$('body').addSwipeEvents().
-		bind('tap', swipeLeft).         // next
-		bind('swipeleft', swipeLeft).   // next
-		bind('swiperight', swipeRight); // prev
 
 	removeResults();
 
@@ -419,23 +420,12 @@ function keyUp(event) {
 	}
 }
 
-
-var lastSwipeLeft = (+new Date());
-var lastSwipeRight = (+new Date());
 function swipeLeft() {
-  var time = (+new Date());
-  if((time - lastSwipeLeft) > 100) {
-    lastSwipeLeft = time;
-    nextStep();
-  }
+  nextStep();
 }
 
 function swipeRight() {
-  var time = (+new Date());
-  if((time - lastSwipeRight) > 100) {
-    lastSwipeRight = time;
-    prevStep();
-  }
+  prevStep();
 }
 
 function ListMenu(s)

--- a/views/index.erb
+++ b/views/index.erb
@@ -6,6 +6,8 @@
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
   <title><%= @title %></title>
 
+  <meta name="viewport" content="width=device-width"/>
+
   <link rel="stylesheet" href="<%= @asset_path %>css/reset.css" type="text/css"/>
   <link rel="stylesheet" href="<%= @asset_path %>css/showoff.css" type="text/css"/>
 


### PR DESCRIPTION
First commit adds a viewport tag which prevents swipe actions from making the currently active slide bounce. Second commit is an improved fix for #57 preventing event handlers being registered multiple times.
