### PR TITLE
BlueCloth + showoff + 1.9.2 not compatible

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -23,6 +23,9 @@ end
 begin
   require 'rdiscount'
 rescue LoadError
+  if RUBY_VERSION =~ /^1.9/
+    raise LoadError,'BlueCloth with #{RUBY_VERSION} is not compatible with showoff; please gem install rdiscount'
+  end
   require 'bluecloth'
   Object.send(:remove_const,:Markdown)
   Markdown = BlueCloth


### PR DESCRIPTION
I get a `Encoding::UndefinedConversionError - U+2026 from UTF-8 to ASCII-8BIT:` when _not_ using rdiscount and running on Ruby 1.9.2.  This occurs in the call to `.to_html`.

This happens to all of my presentations, so this patch doesn't rescue the `LoadError` from attempting to first require rdiscount; it lets it pass for Ruby 1.9.x
