### PR TITLE
Add support for multi-line and root commands when using commandline.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -101,7 +101,7 @@ Some useful styles for each slide are:
 * smbullets - sizes and separates more bullets (smaller, closer together)
 * subsection - creates a different background for titles
 * command - monospaces h1 title slides
-* commandline - for pasted commandline sections (needs leading '$' for commands, then output on subsequent lines)
+* commandline - for pasted commandline sections (needs leading '$' or '#' for commands, then output on subsequent lines; long commands can be split over multiple lines by using a back slash before a newline)
 * code - monospaces everything on the slide
 * incremental - can be used with 'bullets' and 'commandline' styles, will incrementally update elements on arrow key rather than switch slides
 * small - make all slide text 80%

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -178,19 +178,16 @@ class ShowOff < Sinatra::Application
 
       html.css('.commandline > pre > code').each do |code|
         out = code.text
-        lines = out.split(/^\$(.*?)$/)
-        lines.delete('')
+        lines = out.scan(/(?:[\$#](?:[^\n]+?(?:\\\n)?)+|[^\$#]+)\n?/)
         code.content = ''
-        while(lines.size > 0) do
-          command = lines.shift
-          result = lines.shift
+        lines.each do |line|
           c = Nokogiri::XML::Node.new('code', html)
-          c.set_attribute('class', 'command')
-          c.content = '$' + command
-          code << c
-          c = Nokogiri::XML::Node.new('code', html)
-          c.set_attribute('class', 'result')
-          c.content = result
+          if "$" == line[0, 1] || "#" == line[0, 1]
+            c.set_attribute('class', 'command')
+          else
+            c.set_attribute('class', 'result')
+          end
+          c.content = line
           code << c
         end
       end


### PR DESCRIPTION
When using the "commandline" slide style, you can now start commands
with either $ or # and split commands over multiple lines by using a
back slash.

e.g.
    # some root command
    some output
    $ some really long \
      command over several \
      lines
    some output
    that goes over
    several lines

This works by changing the previous split regular expression that split the string on "$..." to a scan which looks specifically for lines of the following pattern:
- $ or # followed by a non-newline and then zero or more lines after a line ending with a backslash;
- Any block of text that doesn't begin with a $ or #.
