### PR TITLE
Move ShowOff::VERSION into its own file.

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -31,7 +31,8 @@ require 'pp'
 
 class ShowOff < Sinatra::Application
 
-  Version = VERSION = '0.4.2'
+  autoload :Version, 'showoff/version'
+  autoload :VERSION, 'showoff/version'
 
   attr_reader :cached_image_size
 

--- a/lib/showoff/version.rb
+++ b/lib/showoff/version.rb
@@ -1,0 +1,3 @@
+class ShowOff
+  VERSION = Version = "0.4.2"
+end

--- a/showoff.gemspec
+++ b/showoff.gemspec
@@ -1,4 +1,4 @@
-require './lib/showoff'
+require './lib/showoff/version'
 Gem::Specification.new do |s|
   s.name              = "showoff"
   s.version           = ShowOff::Version


### PR DESCRIPTION
This means that ShowOff's dependencies can now be loaded from the
gemspec.

On a related note: is there a reason both Version and VERSION are specified?
