### PR TITLE
Modify multiline command line syntax to require >.

### DIFF
--- a/example/one/slidesB.md
+++ b/example/one/slidesB.md
@@ -38,9 +38,14 @@
     some output
 
     $ command over \
-      several lines
+    > two lines
     some more output
     over several lines
+
+    $ command over \
+    > more than two \
+    > lines
+    some output
 
     $ no output command with \( backslashes \)
     $ command

--- a/lib/commandline_parser.rb
+++ b/lib/commandline_parser.rb
@@ -22,10 +22,10 @@ class CommandlineParser < Parslet::Parser
   rule(:multiline_input) do
 
     # some command \
-    # continued \
-    # \
-    # and stop
-    ( singleline_input >> str('\\') >> newline ).repeat(1) >> singleline_input
+    # > continued \
+    # > \
+    # > and stop
+    ( singleline_input >> str('\\') >> newline >> str('>') ).repeat(1) >> singleline_input
   end
 
   rule(:command) do


### PR DESCRIPTION
This makes multiline commands more consistent with real console output
and other parsers such as Pygments' "console" syntax.
