### PR TITLE
Restrict Path changes on images if path references root

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -156,7 +156,7 @@ class ShowOff < Sinatra::Application
       replacement_prefix = static ?
         ( pdf ? %(img src="file://#{options.pres_dir}/#{path}) : %(img src="./file/#{path}) ) :
         %(img src="/image/#{path})
-      slide.gsub(/img src=\"(.*?)\"/) do |s|
+      slide.gsub(/img src=\"([^\/].*?)\"/) do |s|
         img_path = File.join(path, $1)
         w, h     = get_image_size(img_path)
         src      = %(#{replacement_prefix}/#{$1}")


### PR DESCRIPTION
I changed the gsub statement for src="... to not modify the image src path if the existing path starts with a forward slash, denoting a root image reference.
