### PR TITLE
fixed regression caused by ee20a616178ac9c1bc4bc679a346ea6fa0f793f1 which

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -275,7 +275,7 @@ class ShowOff < Sinatra::Application
             files = []
             files << load_section_files(section)
             files = files.flatten
-            files = files.select { |f| f =~ /.md/ }
+            files = files.select { |f| f =~ /.md$/ }
             files.each do |f|
               fname = f.gsub(options.pres_dir + '/', '').gsub('.md', '')
               data << process_markdown(fname, File.read(f), static, pdf)


### PR DESCRIPTION
fixed regression caused by ee20a616178ac9c1bc4bc679a346ea6fa0f793f1 which re-enabled reading of emacs temporary files (i.e. ending in .md~) as presentation files
