### PR TITLE
reset preso width after going full-page

### DIFF
--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -195,6 +195,8 @@ function showSlide(back_step) {
 	if (fullPage) {
 		$('#preso').css({'width' : '100%', 'overflow' : 'visible'});
 		currentSlide.css({'width' : '100%', 'text-align' : 'center', 'overflow' : 'visible'});
+	} else {
+		$('#preso').css({'width' : '1020px', 'overflow' : 'hidden'});
 	}
 
 	percent = getSlidePercent()


### PR DESCRIPTION
If you have a single slide that's full-page, the next slide doesn't get centered properly.  This patch re-centers the #preso element.
