### PR TITLE
adding 'fixed-top' slide attribute

### DIFF
--- a/lib/showoff_utils.rb
+++ b/lib/showoff_utils.rb
@@ -112,6 +112,7 @@ class ShowOffUtils
     'code' => lambda { |t,size,src| make_slide(t,size,blank?(src) ? "    @@@ Ruby\n    code_here()" : src) },
     'commandline' => lambda { |t,size,dontcare| make_slide(t,"#{size} commandline","    $ command here\n    output here")},
     'full-page' => lambda { |t,size,dontcare| make_slide(t,"#{size} full-page","![Image Description](image/ref.png)")},
+    'fixed-top' => lambda { |t,size,dontcare| make_slide(t,"#{size} fixed-top","![Image Description](image/ref.png)")},
   }
 
 

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -102,12 +102,15 @@ function centerSlides(slides) {
 
 function centerSlide(slide) {
 	var slide_content = $(slide).children(".content").first()
+	var fixedTop = $(slide).find(".content").is('.fixed-top');
 	var height = slide_content.height()
 	var mar_top = (0.5 * parseFloat($(slide).height())) - (0.5 * parseFloat(height))
 	if (mar_top < 0) {
 		mar_top = 0
 	}
-	slide_content.css('margin-top', mar_top)
+	if (!fixedTop) {
+		slide_content.css('margin-top', mar_top);
+	}
 }
 
 function setupMenu() {


### PR DESCRIPTION
This adds a fixed-top attribute which prevents a given slide from being vertically centered.  It's useful for progressively revealing content.

Without: http://drop.endot.org/without_fixed-top.gif
With: http://drop.endot.org/with_fixed-top.gif
