### PR TITLE
Split ALL the h1s

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -427,6 +427,7 @@ These options are specified *after* the command.
 [<tt>-f, --pres_file=arg</tt>] Presentation file <i>(default: <tt>showoff.json</tt>)</i>
 [<tt>-h, --host=arg</tt>] Host or ip to run on <i>( default: <tt>localhost</tt>)</i>
 [<tt>-p, --port=arg</tt>] Port on which to run <i>( default: <tt>9090</tt>)</i>
+[<tt>-s, --split</tt>] Split slides on every H1 <i>( default: <tt>false</tt>)</i>
 
 
 == <tt>showoff static name</tt>
@@ -510,6 +511,8 @@ So far, ShowOff has been used in the following presentations (and many others):
   http://github.com/alexch/workshop
 * SDRuby Lightning Talk - Readable Regexps - Ian Young
   https://github.com/iangreenleaf/sdruby-lightningtalk-tregexp
+* "Ruby Notes" tutorial slides - Alex Chaffee
+  https://github.com/alexch/ruby_notes
 
 
 If you use it for something, please let me know so I can add it.

--- a/bin/showoff
+++ b/bin/showoff
@@ -100,11 +100,15 @@ command :serve do |c|
 
   c.desc 'Host or ip to run on'
   c.default_value "localhost"
-  c.flag [:h,:host]  
+  c.flag [:h,:host]
 
   c.desc 'JSON file used to describe presentation'
   c.default_value "showoff.json"
   c.flag [:f, :pres_file]
+
+  c.desc 'every H1 (lone #) in the markdown file will become a new slide'
+  c.default_value false
+  c.switch [:s, :split]
 
   c.action do |global_options,options,args|
 
@@ -121,7 +125,12 @@ To run it from presenter view, go to: [ #{url}/presenter ]
 -------------------------
 
 "
-    ShowOff.run! :host => options[:h], :port => options[:p].to_i, :pres_file => options[:f], :pres_dir => args[0], :verbose => options[:verbose]
+    ShowOff.run! :host => options[:h],
+      :port => options[:p].to_i,
+      :pres_file => options[:f],
+      :pres_dir => args[0],
+      :verbose => options[:verbose],
+      :split => options[:split]
   end
 end
 

--- a/test/split_test.rb
+++ b/test/split_test.rb
@@ -1,0 +1,129 @@
+require File.expand_path "../test_helper", __FILE__
+
+context "splitting Markdown into slides" do
+
+  def app
+    opt = {:verbose => false, :pres_dir => "test/fixtures/simple", :pres_file => 'showoff.json'}
+    ShowOff.set opt
+    @showoff = ShowOff.new
+  end
+
+  setup do
+  end
+
+  test "from an empty string" do
+    slides = ShowOff::Slide.split ""
+    assert_empty slides
+  end
+
+  test "from a simple chunk of Markdown" do
+    slides = ShowOff::Slide.split <<-MARKDOWN
+# One
+* uno
+    MARKDOWN
+    assert_equal 1, slides.size
+    assert_equal ["content"], slides.first.classes
+    assert_equal "# One\n* uno\n", slides.first.text
+  end
+
+    test "from a simple chunk of Markdown with slide markers" do
+      slides = ShowOff::Slide.split <<-MARKDOWN
+!SLIDE cool
+# One
+* uno
+
+!SLIDE neat
+# Two
+* dos
+      MARKDOWN
+      assert_equal 2, slides.size
+      slide = slides.first
+      assert_equal ["content", "cool"], slide.classes
+      assert_equal "# One\n* uno\n\n", slides.first.text
+      slide = slides[1]
+      assert_equal ["content", "neat"], slide.classes
+      assert_equal "# Two\n* dos\n", slide.text
+    end
+
+    test "from a simple chunk of Markdown with comment-style slide markers" do
+      slides = ShowOff::Slide.split <<-MARKDOWN
+<!SLIDE cool>
+# One
+* uno
+
+<!SLIDE neat>
+# Two
+* dos
+      MARKDOWN
+      assert_equal 2, slides.size
+      slide = slides.first
+      assert_equal ["content", "cool"], slide.classes
+      assert_equal "# One\n* uno\n\n", slides.first.text
+      slide = slides[1]
+      assert_equal ["content", "neat"], slide.classes
+      assert_equal "# Two\n* dos\n", slide.text
+    end
+
+
+    test "omits empty slides" do
+      slides = ShowOff::Slide.split <<-MARKDOWN
+!SLIDE
+# One
+* uno
+
+!SLIDE
+
+!SLIDE
+# Two
+* dos
+      MARKDOWN
+      assert_equal 2, slides.size
+    end
+
+    test "if there are no !SLIDE markers at all, then every H1 defines a new slide" do
+      slides = ShowOff::Slide.split <<-MARKDOWN
+# One
+* uno
+
+# Two
+* dos
+      MARKDOWN
+      assert_equal 2, slides.size
+      slide = slides.first
+      assert_equal ["content"], slide.classes
+      assert_equal "# One\n* uno\n\n", slides.first.text
+      slide = slides[1]
+      assert_equal ["content"], slide.classes
+      assert_equal "# Two\n* dos\n", slide.text
+    end
+
+    test "every H1 defines a new slide" do
+      # Until we figure out how to specify this setting at the app level,
+      # this option will only be set from inside this test. This test
+      # will probably become simpler then.
+      varied = <<-MARKDOWN
+<!SLIDE>
+# One
+* uno
+
+# Two
+* dos
+      MARKDOWN
+
+      slides = ShowOff::Slide.split varied
+      assert_equal 1, slides.size
+
+      slides = ShowOff::Slide.split varied, :split_all_the_h1s => false
+      assert_equal 1, slides.size
+
+      slides = ShowOff::Slide.split varied, :split_all_the_h1s => true
+      assert_equal 2, slides.size
+      slide = slides.first
+      assert_equal ["content"], slide.classes
+      assert_equal "# One\n* uno\n\n", slides.first.text
+      slide = slides[1]
+      assert_equal ["content"], slide.classes
+      assert_equal "# Two\n* dos\n", slide.text
+    end
+
+end


### PR DESCRIPTION
Testing and refactoring the first part of the "process_markdown" method. I stuck in an implementation of my pet "Split ALL the H1s" feature but I can take it out if you just want the tests for the moment. Or just ignore this pull request until we figure out (and I implement) how to configure it from the top level, or whether we want the feature on all the time (in which case I'd un-break the example preso and stuff).

![ALL](http://images.memegenerator.net/instances/400x/10262616.jpg)
