### PR TITLE
Make ShowOff compatible with Rack::URLMap

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -188,7 +188,7 @@ class ShowOff < Sinatra::Application
       path = paths.join('/')
       replacement_prefix = static ?
         ( pdf ? %(img src="file://#{options.pres_dir}/#{path}) : %(img src="./file/#{path}) ) :
-        %(img src="/image/#{path})
+        %(img src="#{@asset_path}image/#{path})
       slide.gsub(/img src=\"([^\/].*?)\"/) do |s|
         img_path = File.join(path, $1)
         w, h     = get_image_size(img_path)
@@ -203,7 +203,7 @@ class ShowOff < Sinatra::Application
     if defined?(Magick)
       def get_image_size(path)
         if !cached_image_size.key?(path)
-          img = Magick::Image.ping(path).first
+          img = Magick::Image.ping(File.join(@asset_path, path)).first
           # don't set a size for svgs so they can expand to fit their container
           if img.mime_type == 'image/svg+xml'
             cached_image_size[path] = [nil, nil]
@@ -483,6 +483,7 @@ class ShowOff < Sinatra::Application
     @title = ShowOffUtils.showoff_title
     what = params[:captures].first
     what = 'index' if "" == what
+    @asset_path = (env['SCRIPT_NAME'] || '').gsub(/\/?$/, '/').gsub(/^\//, '')
     if (what != "favicon.ico")
       data = send(what)
       if data.is_a?(File)

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -50,7 +50,7 @@ function setupPreso(load_slides, prefix) {
 function loadSlides(load_slides, prefix) {
 	//load slides offscreen, wait for images and then initialize
 	if (load_slides) {
-		$("#slides").load("slides", false, function(){
+		$("#slides").load(loadSlidesPrefix + "slides", false, function(){
 			$("#slides img").batchImageLoad({
 			loadingCompleteCallback: initializePresentation(prefix)
 		})

--- a/views/header.erb
+++ b/views/header.erb
@@ -26,11 +26,11 @@
   <link type="text/css" href="<%= @asset_path %>css/sh_style.css" rel="stylesheet" >
 
   <% css_files.each do |css_file| %>
-    <link rel="stylesheet" href="file/<%= css_file %>" type="text/css"/>
+    <link rel="stylesheet" href="<%= @asset_path %>file/<%= css_file %>" type="text/css"/>
   <% end %>
 
   <% js_files.each do |js_file| %>
-    <script type="text/javascript" src="file/<%= js_file %>"></script>
+    <script type="text/javascript" src="<%= @asset_path %>file/<%= js_file %>"></script>
   <% end %>
 
   <script type="text/javascript">


### PR DESCRIPTION
If you try to mount a ShowOff deck under a path with Rack::URLMap, that paths to the assets are not correct. I've added `@asset_path` to a few places to make sure decks load correctly if you want to host multiple decks on one domain.
