### PR TITLE
Replace BlueCloth, it's broken

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,6 @@
 source :rubygems
 
-gem "sinatra"
-gem "bluecloth"
-gem "nokogiri"
-gem "json"
-gem "gli",">= 1.2.5"
-gem "parslet"
+gemspec
 
 group :development do
   gem "mg"

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -21,13 +21,7 @@ rescue LoadError
   $stderr.puts 'pdf generation disabled - install pdfkit'
 end
 
-begin
-  require 'rdiscount'
-rescue LoadError
-  require 'bluecloth'
-  Object.send(:remove_const,:Markdown)
-  Markdown = BlueCloth
-end
+require 'tilt'
 
 class ShowOff < Sinatra::Application
 
@@ -166,7 +160,7 @@ class ShowOff < Sinatra::Application
         else
           md += "<div class=\"#{content_classes.join(' ')}\" ref=\"#{name}\">\n"
         end
-        sl = Markdown.new(slide.text).to_html
+        sl = Tilt[:markdown].new { slide.text }.render
         sl = update_image_paths(name, sl, static, pdf)
         md += sl
         md += "</div>\n"

--- a/lib/showoff_utils.rb
+++ b/lib/showoff_utils.rb
@@ -294,7 +294,7 @@ class ShowOffUtils
     EXTENSIONS[ext] || ext
   end
 
-  REQUIRED_GEMS = %w(bluecloth nokogiri showoff gli heroku)
+  REQUIRED_GEMS = %w(redcarpet showoff heroku)
 
   # Creates the file that lists the gems for heroku
   #

--- a/showoff.gemspec
+++ b/showoff.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |s|
   s.files            += Dir.glob("bin/**/*")
   s.files            += Dir.glob("views/**/*")
   s.files            += Dir.glob("public/**/*")
-  s.add_dependency      "sinatra"
-  s.add_dependency      "bluecloth"
+  s.add_dependency      "sinatra", "~> 1.3"
+  s.add_dependency      "redcarpet"
   s.add_dependency      "nokogiri"
   s.add_dependency      "json"
   s.add_dependency("gli",">= 1.3.2")

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -21,10 +21,7 @@ context "ShowOff Utils tests" do
       ShowOffUtils.heroku('test')
       files = Dir.glob('**/*')
       content = File.read('Gemfile')
-      assert_match 'bluecloth', content
-      assert_match 'nokogiri', content
       assert_match 'showoff', content
-      assert_match 'gli', content
       assert_match 'heroku', content
     end
     assert files.include?('config.ru')


### PR DESCRIPTION
With a recent Sinatra version, we have tilt anyway and should use it's preferred markdown engine redcloth instead.
