### PR TITLE
Templating + Fixes for Static and PDF Generation

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -84,7 +84,23 @@ the following contents:
 
 That represents two slides, the first contains just a large title, and the
 second is faded into view showing the title and three bullets that are then
-incrementally shown. In order for ShowOff to see those slides, your
+incrementally shown. In addition you can configure a certain template for 
+this slide overriding the default one:
+
+     !SLIDE[tpl=title]
+
+     # My Presentation #
+
+     !SLIDE bullets incremental
+
+     # Bullet Points #
+
+     * first point
+     * second point
+     * third point
+
+
+In order for ShowOff to see those slides, your
 <tt>showoff.json</tt> file needs to look something like this:
 
     {
@@ -95,19 +111,40 @@ incrementally shown. In order for ShowOff to see those slides, your
       ]
     }
 
-If you have multiple sections in your talk, you can make this json array
-include all the sections you want to show in which order you want to show
-them.
+If you have multiple sections in your talk, you can make this json
+array include all the sections you want to show in which order you
+want to show them. Template configuration is done in
+<tt>showoff.json</tt> as well. 
 
-Instead of a hash, you can use a plain string as an entry in the `sections`
-section of `showoff.json`.
 
-And if that plain string starts with '#' then it is interpreted not as a
-filename, but as markdown. This is used for inserting interstitial slides
-or notes -- for instance, Alex Chaffee's
-[Ruby Notes](http://github.com/alexch/ruby_notes)
-uses it to insert lab instructions between lecture slide sections, which may
-vary from venue to venue.
+To configure your own template add an
+entry called "templates". This entry is an object where you can
+specify as many templates as you want. The default template is marked
+with the "default" key.
+
+     {
+      "name": "Something",
+      "description": "Example Presentation",
+      "templates" : {
+          "default" : "tpl1.tpl",
+	  "special" : "tpl2.tpl"
+      },    
+      "sections": [
+        {"section":"one"}
+      ]
+    }
+
+If the "default" key is not given, no template will be used for the
+default slide.
+
+Instead of a hash, you can use a plain string as an entry in the
+`sections` section of `showoff.json`. And if that plain string starts
+with '#' then it is interpreted not as a filename, but as
+markdown. This is used for inserting interstitial slides or notes --
+for instance, Alex Chaffee's [Ruby
+Notes](http://github.com/alexch/ruby_notes) uses it to insert lab
+instructions between lecture slide sections, which may vary from venue
+to venue.
 
 If you want to keep the ability to emit an HTML document from your
 Markdown source file -- say, for a TextMate preview or a GitHub rendering

--- a/README.rdoc
+++ b/README.rdoc
@@ -495,7 +495,20 @@ have to specify it in the slide header:
 You can place content anywhere in your template, but you have to
 explicitly mark the location using a special command:
 
-[###CONTENT###] is replaced by the slide content
+[~~~CONTENT~~~] is replaced by the slide content
+
+[~~~CURRENT_SLIDE~~~] is replaced by the current slide number
+
+[~~~NUM_SLIDES~~~] is replaced by the total number of slides
+
+[~~~CONFIG:*~~~] is replaced by any value (*) from the
+                 <tt>showoff.json</tt> configuration. This can be used to 
+		 specify an author, venue etc. A simple example would be
+		 <tt>~~~CONFIG:author~~~</tt>
+
+
+The usage of these replacements is not limited to templates, but
+anywhere in your slides. 
 
 == Template Hints
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -495,7 +495,7 @@ have to specify it in the slide header:
 You can place content anywhere in your template, but you have to
 explicitly mark the location using a special command:
 
-    * ###CONTENT### - is replaced by the slide content
+[###CONTENT###] is replaced by the slide content
 
 == Template Hints
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -117,26 +117,6 @@ want to show them. Template configuration is done in
 <tt>showoff.json</tt> as well. 
 
 
-To configure your own template add an
-entry called "templates". This entry is an object where you can
-specify as many templates as you want. The default template is marked
-with the "default" key.
-
-     {
-      "name": "Something",
-      "description": "Example Presentation",
-      "templates" : {
-          "default" : "tpl1.tpl",
-	  "special" : "tpl2.tpl"
-      },    
-      "sections": [
-        {"section":"one"}
-      ]
-    }
-
-If the "default" key is not given, no template will be used for the
-default slide.
-
 Instead of a hash, you can use a plain string as an entry in the
 `sections` section of `showoff.json`. And if that plain string starts
 with '#' then it is interpreted not as a filename, but as
@@ -482,6 +462,49 @@ You'll then need to install a version of wkhtmltopdf available at the {wkhtmltop
 
 
 Then restart showoff, and navigate to <tt>/pdf</tt> (e.g. http://localhost/pdf) of your presentation and a PDF will be generated with the browser.
+
+= ShowOff Templates
+
+Templates can come handy if you need more than what you can achieve
+via CSS. To configure templates you'll have to specify them in the
+<tt>showoff.json</tt> by adding an entry called "templates". This
+entry is an object where you can specify as many templates as you
+want. The default template is marked with the "default" key.
+
+     {
+      "name": "Something",
+      "description": "Example Presentation",
+      "templates" : {
+          "default" : "tpl1.tpl",
+	  "special" : "tpl2.tpl"
+      },    
+      "sections": [
+        {"section":"one"}
+      ]
+    }
+
+If the "default" key is not given, no template will be used for the
+default slide. If you want to apply a certain layout to a slide you
+have to specify it in the slide header:
+
+     !SLIDE[tpl=special]
+     # Header
+
+== Template Commands
+
+You can place content anywhere in your template, but you have to
+explicitly mark the location using a special command:
+
+    * ###CONTENT### - is replaced by the slide content
+
+== Template Hints
+
+You can basically put everything you want into templates, but you
+should make sure that the CSS is applied fine. The best way to apply a
+custom layout is to create a container that uses absolute positioning
+and has width and height set to 100% which are then derived from the
+parent slide element.
+
 
 = Completion
 

--- a/example/four/01slide.md
+++ b/example/four/01slide.md
@@ -1,0 +1,5 @@
+!SLIDE[tpl=special]
+
+# A Template #
+
+Really? How many slides? -- ~~~NUM_SLIDES~~~

--- a/example/showoff.json
+++ b/example/showoff.json
@@ -1,9 +1,14 @@
 {
   "name": "Something",
   "description": "Example Presentation",
+  "author": "Foo Bar John",
+  "templates" : {
+      "special" : "simple.tpl"
+  },
   "sections": [
     {"section":"one"},
     {"section":"two"},
-    {"section":"three"}
+    {"section":"three"},
+    {"section":"four"}
   ]
 }

--- a/example/simple.tpl
+++ b/example/simple.tpl
@@ -1,0 +1,2 @@
+<div class="border">~~~CONFIG:author~~~@~~~CURRENT_SLIDE~~~</div>
+<div class="main">~~~CONTENT~~~<div>

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -190,26 +190,36 @@ class ShowOff < Sinatra::Application
         md += " class=\"slide\" data-transition=\"#{transition}\">"
 
 
+        template = "###CONTENT###"
         # Template handling
         if options.pres_template
           # We allow specifying a new template even when default is
           # not given.
           if options.pres_template.include?(slide.tpl) and
               File.exists?(options.pres_template[slide.tpl])
-            md += File.open(options.pres_template[slide.tpl], "r").read()
+            template = File.open(options.pres_template[slide.tpl], "r").read()
           end
         end
 
+
+        # Extract the content of the slide
+        content = ""
+
         if seq
-          md += "<div class=\"#{content_classes.join(' ')}\" ref=\"#{name}/#{seq.to_s}\">\n"
+          content += "<div class=\"#{content_classes.join(' ')}\" ref=\"#{name}/#{seq.to_s}\">\n"
           seq += 1
         else
-          md += "<div class=\"#{content_classes.join(' ')}\" ref=\"#{name}\">\n"
+          content += "<div class=\"#{content_classes.join(' ')}\" ref=\"#{name}\">\n"
         end
         sl = Markdown.new(slide.text).to_html
         sl = update_image_paths(name, sl, static, pdf)
-        md += sl
-        md += "</div>\n"
+        content += sl
+        content += "</div>\n"
+
+        # Apply the template to the slide and replace the key with
+        # content of the slide
+        md += template.gsub(/###CONTENT###/, content)
+
         md += "</div>\n"
         final += update_commandline_code(md)
         final = update_p_classes(final)

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -497,7 +497,10 @@ class ShowOff < Sinatra::Application
       end
       name = showoff.instance_variable_get(:@pres_name)
       path = showoff.instance_variable_get(:@root_path)
+      logger = showoff.instance_variable_get(:@logger)
+
       data = showoff.send(what, true)
+
       if data.is_a?(File)
         FileUtils.cp(data.path, "#{name}.pdf")
       else
@@ -542,7 +545,7 @@ class ShowOff < Sinatra::Application
           File.open(css_path) do |file|
             data = file.read
             data.scan(/url\((.*)\)/).flatten.each do |path|
-              #@logger.debug path
+              logger.debug path
               dir = File.dirname(path)
               FileUtils.makedirs(File.join(file_dir, dir))
               FileUtils.copy(File.join(pres_dir, path), File.join(file_dir, path))

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -175,6 +175,7 @@ class ShowOff < Sinatra::Application
         seq = 1
       end
       slides.each do |slide|
+        @slide_count += 1
         md = ''
         content_classes = slide.classes
 
@@ -219,7 +220,7 @@ class ShowOff < Sinatra::Application
 
         # Apply the template to the slide and replace the key with
         # content of the slide
-        md += process_content_for_replacements(template.gsub(/~~~CONTENT~~~/, content), seq, slides.size)
+        md += process_content_for_replacements(template.gsub(/~~~CONTENT~~~/, content), @slide_count)
 
         # Apply other configuration
 
@@ -227,23 +228,27 @@ class ShowOff < Sinatra::Application
         final += update_commandline_code(md)
         final = update_p_classes(final)
 
-        seq += 1
+        if seq
+          seq += 1
+        end
       end
       final
     end
 
     # This method processes the content of the slide and replaces
     # content markers with their actual value information
-    def process_content_for_replacements(content, seq, num)
-      result = content.gsub("~~~CURRENT_SLIDE~~~", seq.to_s).
-        gsub("~~~NUM_SLIDES~~~", num.to_s)
-
+    def process_content_for_replacements(content, seq)
+      result = content.gsub("~~~CURRENT_SLIDE~~~", seq.to_s)
       # Now check for any kind of options
       content.scan(/(~~~CONFIG:(.*?)~~~)/).each do |match|
         result.gsub!(match[0], options.showoff_config[match[1]]) if options.showoff_config.key?(match[1])
       end
 
       result
+    end
+
+    def process_content_for_all_slides(content, num_slides)
+      content.gsub("~~~NUM_SLIDES~~~", num_slides.to_s)
     end
     
 
@@ -335,6 +340,7 @@ class ShowOff < Sinatra::Application
     end
 
     def get_slides_html(static=false, pdf=false)
+      @slide_count = 0
       sections = ShowOffUtils.showoff_sections(options.pres_dir, @logger)
       files = []
       if sections
@@ -355,7 +361,7 @@ class ShowOff < Sinatra::Application
           end
         end
       end
-      data
+      process_content_for_all_slides(data, @slide_count)
     end
 
     def inline_css(csses, pre = nil)

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -394,6 +394,11 @@ class ShowOff < Sinatra::Application
       if static
         @title = ShowOffUtils.showoff_title
         @slides = get_slides_html(static)
+
+        # Identify which languages to bundle for highlighting
+        @languages = []
+        @languages += @slides.scan(/<pre class="(sh_.*?\w)"/).uniq.map{ |w| "sh_lang/#{w[0]}.min.js"}
+
         @asset_path = "./"
       end
       erb :index
@@ -452,6 +457,10 @@ class ShowOff < Sinatra::Application
     def pdf(static=true)
       @slides = get_slides_html(static, true)
       @no_js = false
+
+      # Identify which languages to bundle for highlighting
+      @languages = []
+      @languages += @slides.scan(/<pre class="(sh_.*?\w)"/).uniq.map{ |w| "/sh_lang/#{w[0]}.min.js"}
 
       html = erb :onepage
       # TODO make a random filename

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -36,7 +36,7 @@ class ShowOff < Sinatra::Application
   attr_reader :cached_image_size
 
   set :views, File.dirname(__FILE__) + '/../views'
-  set :public, File.dirname(__FILE__) + '/../public'
+  set :public_folder, File.dirname(__FILE__) + '/../public'
 
   set :verbose, false
   set :pres_dir, '.'
@@ -194,7 +194,7 @@ class ShowOff < Sinatra::Application
         md += " class=\"slide\" data-transition=\"#{transition}\">"
 
 
-        template = "###CONTENT###"
+        template = "~~~CONTENT~~~"
         # Template handling
         if options.pres_template
           # We allow specifying a new template even when default is
@@ -436,10 +436,10 @@ class ShowOff < Sinatra::Application
         assets << href if href
       end
 
-      css = Dir.glob("#{options.public}/**/*.css").map { |path| path.gsub(options.public + '/', '') }
+      css = Dir.glob("#{options.public_folder}/**/*.css").map { |path| path.gsub(options.public_folder + '/', '') }
       assets << css
 
-      js = Dir.glob("#{options.public}/**/*.js").map { |path| path.gsub(options.public + '/', '') }
+      js = Dir.glob("#{options.public_folder}/**/*.js").map { |path| path.gsub(options.public_folder + '/', '') }
       assets << js
 
       assets.uniq.join("\n")
@@ -577,6 +577,7 @@ class ShowOff < Sinatra::Application
     @title = ShowOffUtils.showoff_title
     what = params[:captures].first
     what = 'index' if "" == what
+
     if (what != "favicon.ico")
       data = send(what)
       if data.is_a?(File)

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -59,15 +59,15 @@ class ShowOff < Sinatra::Application
     # configuration JSON file
     if File.exists?(ShowOffUtils.presentation_config_file)
       showoff_json = JSON.parse(File.read(ShowOffUtils.presentation_config_file))
-      options.showoff_config = showoff_json
+      settings.showoff_config = showoff_json
       
       # Set options for template and page size
-      options.page_size = showoff_json["page-size"] || "Letter"
-      options.pres_template = showoff_json["templates"] 
+      settings.page_size = showoff_json["page-size"] || "Letter"
+      settings.pres_template = showoff_json["templates"] 
     end
 
 
-    @logger.debug options.pres_template
+    @logger.debug settings.pres_template
 
     @cached_image_size = {}
     @logger.debug settings.pres_dir
@@ -192,12 +192,12 @@ class ShowOff < Sinatra::Application
 
         template = "~~~CONTENT~~~"
         # Template handling
-        if options.pres_template
+        if settings.pres_template
           # We allow specifying a new template even when default is
           # not given.
-          if options.pres_template.include?(slide.tpl) and
-              File.exists?(options.pres_template[slide.tpl])
-            template = File.open(options.pres_template[slide.tpl], "r").read()
+          if settings.pres_template.include?(slide.tpl) and
+              File.exists?(settings.pres_template[slide.tpl])
+            template = File.open(settings.pres_template[slide.tpl], "r").read()
           end
         end
 
@@ -236,7 +236,7 @@ class ShowOff < Sinatra::Application
       result = content.gsub("~~~CURRENT_SLIDE~~~", seq.to_s)
       # Now check for any kind of options
       content.scan(/(~~~CONFIG:(.*?)~~~)/).each do |match|
-        result.gsub!(match[0], options.showoff_config[match[1]]) if options.showoff_config.key?(match[1])
+        result.gsub!(match[0], settings.showoff_config[match[1]]) if settings.showoff_config.key?(match[1])
       end
 
       result
@@ -469,7 +469,7 @@ class ShowOff < Sinatra::Application
       # Process inline css and js for included images 
       # The css uses relative paths for images and we prepend the file url
       html.gsub!(/url\(([^\/].*?)\)/) do |s|
-        "url(file://#{options.pres_dir}/#{$1})"
+        "url(file://#{settings.pres_dir}/#{$1})"
       end
 
       # Todo fix javascript path

--- a/lib/showoff_utils.rb
+++ b/lib/showoff_utils.rb
@@ -1,4 +1,28 @@
 class ShowOffUtils
+
+  # Helper method to parse a comma separated options string and stores
+  # the result in a dictionrary
+  #
+  # Example:
+  # 
+  #    "tpl=hpi,title=Over the rainbow"
+  #
+  #    will be stored as
+  #
+  #      { "tpl" => "hpi", "title" => "Over the rainbow" }
+  def self.parse_options(option_string="")
+    result = {}
+
+    if option_string 
+      option_string.split(",").each do |element|
+        pair = element.split("=")
+        result[pair[0]] = pair.size > 1 ? pair[1] : nil
+      end
+    end
+
+    result
+  end
+
   def self.presentation_config_file
     @presentation_config_file ||= 'showoff.json'
   end

--- a/public/css/onepage.css
+++ b/public/css/onepage.css
@@ -23,6 +23,7 @@
       height: 600px;
       overflow:hidden;
       border: none;
+      position: relative;
       page-break-after: always
   }
 }

--- a/public/css/onepage.css
+++ b/public/css/onepage.css
@@ -9,6 +9,7 @@
       margin-left:auto; 
       margin-right:auto;
       overflow:hidden;
+      position: relative;
       border: 1px solid #333;
       page-break-after: always
   }

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -368,7 +368,7 @@ a.fg-button { float:left; }
   }
 
   .slide .center {
-    width: 600px;
+    width: 800px;
     height: 600px;
     display: table-cell;
     text-align: center;
@@ -377,7 +377,7 @@ a.fg-button { float:left; }
 
   #preso, .slide {
       background: #fff;
-      width: 600px;
+      width: 800px;
       height: 600px;
       margin-left:auto;
       margin-right:auto;

--- a/public/js/onepage.js
+++ b/public/js/onepage.js
@@ -1,4 +1,4 @@
 function setupOnePage() {
-  sh_highlightDocument('/js/sh_lang/', '.min.js')
+  sh_highlightDocument();
   centerSlides($("#slides > .slide"))
 }

--- a/public/js/onepage.js
+++ b/public/js/onepage.js
@@ -1,5 +1,4 @@
 function setupOnePage() {
   sh_highlightDocument('/js/sh_lang/', '.min.js')
-  
   centerSlides($("#slides > .slide"))
 }

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -98,13 +98,6 @@ function initializePresentation(prefix) {
 	    sh_highlightDocument();
 	}
 	$("#preso").trigger("showoff:loaded");
-
-        // Add any initialization hook there is provided
-        $.each(ShowOff.initCallbacks, function(idx, cb){
-	    if (typeof(cb) == "function")
-		cb();
-	});
-
 }
 
 function centerSlides(slides) {

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -28,6 +28,8 @@ function setupPreso(load_slides, prefix) {
 	}
 	preso_started = true
 
+
+        // Load slides fetches images
 	loadSlidesBool = load_slides
 	loadSlidesPrefix = prefix
 	loadSlides(loadSlidesBool, loadSlidesPrefix)
@@ -64,7 +66,7 @@ function loadSlides(load_slides, prefix) {
 
 function initializePresentation(prefix) {
 	// unhide for height to work in static mode
-  $("#slides").show();
+        $("#slides").show();
 
 	//center slides offscreen
 	centerSlides($('#slides > .slide'))
@@ -90,8 +92,19 @@ function initializePresentation(prefix) {
 		slidesLoaded = true
 	}
 	setupSlideParamsCheck();
-	sh_highlightDocument(prefix+'/js/sh_lang/', '.min.js')
+        try {
+	    sh_highlightDocument(prefix+'/js/sh_lang/', '.min.js')
+	} catch(e) {
+	    sh_highlightDocument();
+	}
 	$("#preso").trigger("showoff:loaded");
+
+        // Add any initialization hook there is provided
+        $.each(ShowOff.initCallbacks, function(idx, cb){
+	    if (typeof(cb) == "function")
+		cb();
+	});
+
 }
 
 function centerSlides(slides) {
@@ -101,7 +114,7 @@ function centerSlides(slides) {
 }
 
 function centerSlide(slide) {
-	var slide_content = $(slide).children(".content").first()
+	var slide_content = $(slide).find(".content").first()
 	var height = slide_content.height()
 	var mar_top = (0.5 * parseFloat($(slide).height())) - (0.5 * parseFloat(height))
 	if (mar_top < 0) {
@@ -117,7 +130,7 @@ function setupMenu() {
 	var menu = new ListMenu()
 
 	slides.each(function(s, elem) {
-		content = $(elem).children(".content")
+		content = $(elem).find(".content")
 		shortTxt = $(content).text().substr(0, 20)
 		path = $(content).attr('ref').split('/')
 		currSlide += 1

--- a/views/header.erb
+++ b/views/header.erb
@@ -25,6 +25,10 @@
   <link type="text/css" href="<%= @asset_path %>css/theme/ui.all.css" media="screen" rel="stylesheet" />
   <link type="text/css" href="<%= @asset_path %>css/sh_style.css" rel="stylesheet" >
 
+<% @languages.each do |l| %>
+   <script type="text/javascript" src="<%= @asset_path %>js/<%= l %>"></script>
+<% end %>
+
   <% css_files.each do |css_file| %>
     <link rel="stylesheet" href="file/<%= css_file %>" type="text/css"/>
   <% end %>

--- a/views/header.erb
+++ b/views/header.erb
@@ -25,8 +25,10 @@
   <link type="text/css" href="<%= @asset_path %>css/theme/ui.all.css" media="screen" rel="stylesheet" />
   <link type="text/css" href="<%= @asset_path %>css/sh_style.css" rel="stylesheet" >
 
+<% if @languages %>
 <% @languages.each do |l| %>
    <script type="text/javascript" src="<%= @asset_path %>js/<%= l %>"></script>
+<% end %>
 <% end %>
 
   <% css_files.each do |css_file| %>

--- a/views/onepage.erb
+++ b/views/onepage.erb
@@ -25,10 +25,8 @@
 </head>
 
 <body>
-
 <div id="slides">
   <%= @slides %>
 </div>
-
 </body>
 </html>

--- a/views/onepage.erb
+++ b/views/onepage.erb
@@ -15,7 +15,7 @@
   <%= inline_css(css_files) %>
 
   <% if !@no_js %>
-    <%= inline_js(['jquery-1.4.2.min.js', 'jquery-print.js', 'showoff.js', 'onepage.js', 'sh_main.min.js', 'core.js', 'showoffcore.js'], 'public/js') %>
+    <%= inline_js(['jquery-1.4.2.min.js', 'jquery-print.js', 'showoff.js', 'onepage.js', 'sh_main.min.js', 'core.js', 'showoffcore.js'] + @languages, 'public/js') %>
     <script type="text/javascript">
     $(document).ready(function() {
       setupOnePage()


### PR DESCRIPTION
Hi,

basically this group of commits does a few things. 

First, it implements a way to provide the user with layout templates if he wants and make the pretty configurable . Templates can be applied either per default or per slide. Please have a look at the updated readme for a usage instruction.

Second, I fixed a a few bugs that relate to static HTML and PDF generation. This includes, rewriting URLs used in CSS to point to static file:// URIs, forcing wkthmltopdf to use the print media styles instead of the screen media styles. In addition sytnax highlighting now works both in PDF and static mode.

It would be great if you could review my changes. 

You can find a simple presentation of how to use the templates, made with showoff here - http://grundprinzip.github.com/Showoff-Templates

Thanks
Martin
