### PR TITLE
Tests + Asset Path fixes

### DIFF
--- a/bin/showoff
+++ b/bin/showoff
@@ -2,12 +2,13 @@
 
 $LOAD_PATH.unshift File.join(File.dirname(__FILE__), '..', 'lib')
 require 'showoff'
+require 'showoff/version' 
 require 'rubygems'
 require 'gli'
 
 include GLI
 
-version ShowOff::Version 
+version SHOWOFF_VERSION
 
 desc 'Create new showoff presentation'
 arg_name 'dir_name'

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -34,7 +34,7 @@ class ShowOff < Sinatra::Application
   attr_reader :cached_image_size
 
   set :views, File.dirname(__FILE__) + '/../views'
-  set :public, File.dirname(__FILE__) + '/../public'
+  set :public_folder, File.dirname(__FILE__) + '/../public'
 
   set :verbose, false
   set :pres_dir, '.'
@@ -61,6 +61,9 @@ class ShowOff < Sinatra::Application
     @logger.debug options.pres_dir
     @pres_name = options.pres_dir.split('/').pop
     require_ruby_files
+
+    # Default asset path
+    @asset_path = "./"
   end
 
   def self.pres_dir_current
@@ -359,10 +362,10 @@ class ShowOff < Sinatra::Application
         assets << href if href
       end
 
-      css = Dir.glob("#{options.public}/**/*.css").map { |path| path.gsub(options.public + '/', '') }
+      css = Dir.glob("#{options.public_folder}/**/*.css").map { |path| path.gsub(options.public_folder + '/', '') }
       assets << css
 
-      js = Dir.glob("#{options.public}/**/*.js").map { |path| path.gsub(options.public + '/', '') }
+      js = Dir.glob("#{options.public_folder}/**/*.js").map { |path| path.gsub(options.public_folder + '/', '') }
       assets << js
 
       assets.uniq.join("\n")

--- a/lib/showoff_utils.rb
+++ b/lib/showoff_utils.rb
@@ -293,6 +293,8 @@ class ShowOffUtils
           data[option] || default
         end
       end
+    else
+      default
     end
   end
 


### PR DESCRIPTION
I could not execute the tests because of the following reasons:

1) the get_options() method did not handle the fact that sometimes there is no config file
2) my sinatra version requires public to be not a member variable

In Addition I could not execute the showoff executable from the trunk since it uses ShowOff::VERSION, but one of the previous merges of a pull request made this to SHOWOFF_VERSION
