### PR TITLE
Making markdown engine configurable per slideshow

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -447,6 +447,42 @@ You'll then need to install a version of wkhtmltopdf available at the {wkhtmltop
 
 Then restart showoff, and navigate to <tt>/pdf</tt> (e.g. http://localhost/pdf) of your presentation and a PDF will be generated with the browser.
 
+= Misc
+
+== Markdown Engine
+
+It is possible to configure the markdown engine of your choice to use
+with showoff. This allows you to use special features of the different
+engines.
+
+=== Maruku
+
+When you prefer using Maruku as the markdown engine of choice for your
+presentation, you can use the Latex Math Mode features of
+maruku. First you need
+{BlahTex}[http://www.mediawiki.org/wiki/Extension:Blahtex] and then
+you need to configure your presentation as following:
+
+    { /* other config */,
+     "markdown" : "maruku",
+     "maruku" : {
+     	      "use_tex" : true,
+	      "png_dir" : "images", /*optional*/
+	      "html_png_url" : "/file/images/" /*optional*/
+       }
+     }
+
+
+=== Other Engines
+
+The following engines are preconfigured
+
+* redcarpet (default)
+* bluecloth
+* maruku
+* rdiscount
+
+
 = Completion
 
 == ZSH completion

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -58,6 +58,9 @@ class ShowOff < Sinatra::Application
 
     # Default asset path
     @asset_path = "./"
+
+    # Initialize Markdown Configuration
+    MarkdownConfig::setup( settings.pres_dir )
   end
 
   def self.pres_dir_current

--- a/test/fixtures/maruku/one/01_slide.md
+++ b/test/fixtures/maruku/one/01_slide.md
@@ -1,0 +1,16 @@
+!SLIDE 
+# My Presentation #
+
+!SLIDE bullets incremental
+# Bullet Points #
+
+* first point
+* second point
+* third point
+
+
+!SLIDE 
+
+# Math Mode #
+
+$\forall x \in X; \sum_i=x^i$

--- a/test/fixtures/maruku/showoff.json
+++ b/test/fixtures/maruku/showoff.json
@@ -1,0 +1,7 @@
+{ "name": "My Preso", 
+  "sections": [ {"section":"one"} ],
+  "markdown" : "maruku",
+  "maruku" : {
+      "use_tex" : true
+  }
+}

--- a/test/markdown_test.rb
+++ b/test/markdown_test.rb
@@ -1,0 +1,43 @@
+require File.expand_path "../test_helper", __FILE__
+
+begin
+  require 'maruku'
+  do_maruku = true
+rescue LoadError
+  do_maruku = false
+end
+
+context "ShowOff Maruku tests" do
+ 
+  def app
+    opt = {:verbose => false, :pres_dir => "test/fixtures/maruku", :pres_file => 'showoff.json'}
+    ShowOff.set opt
+    ShowOff.new
+  end
+ 
+  setup do
+  end
+ 
+  test "maruku can get the index page" do
+    get '/'
+    assert last_response.ok?
+    assert_match '<div id="preso">', last_response.body
+  end
+ 
+  test "maruku can get basic slides" do
+    get '/slides'
+    assert last_response.ok?
+    assert_match /<h1(.*?)>My Presentation<\/h1>/, last_response.body
+  end
+
+  test "maruku transforms equation to math mode" do
+    get '/slides'
+    assert_match /<span class="maruku-inline"><img alt="\$\\forall/, last_response.body
+  end
+ 
+  test "maruku can math mode" do
+    assert_equal "maruku", ShowOffUtils.showoff_markdown("test/fixtures/maruku")
+  end
+ 
+ 
+end if do_maruku


### PR DESCRIPTION
Sometimes I need to put math on my slides and this was pretty much a showstopper for showoff for me, but then I discovered Marukus math mode (via Jekyll). Since the markdown engine is now selected via tilt, I added a feature that allows choosing the markdown engine per slideshow (with redcarpet as default).

As a result you can write something like this in your showoff.json 

``` javascript
    { 
        /*other config*/
        "markdown" : "maruku",
        "maruku" : {
            "use_tex" : true
        }
    }
```

And this will render the math formulas using blahtex as images and put them on your slides.

Documentation + Tests included.
