### PR TITLE
Fix PDF Options Bug	

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -382,7 +382,7 @@ class ShowOff < Sinatra::Application
 
       # PDFKit.new takes the HTML and any options for wkhtmltopdf
       # run `wkhtmltopdf --extended-help` for a full list of options
-      kit = PDFKit.new(html, ShowOffUtils.showoff_pdf_options)
+      kit = PDFKit.new(html, ShowOffUtils.showoff_pdf_options(settings.pres_dir))
 
       # Save the PDF to a file
       file = kit.to_file('/tmp/preso.pdf')

--- a/lib/showoff_utils.rb
+++ b/lib/showoff_utils.rb
@@ -288,7 +288,7 @@ class ShowOffUtils
       data = JSON.parse(File.read(index))
       if data.is_a?(Hash)
         if default.is_a?(Hash)
-          default.merge(data[option])
+          default.merge(data[option] || default)
         else
           data[option] || default
         end


### PR DESCRIPTION
The pdf_options call in ShowOff::pdf was missing the working directory for the current presentation. Adding this call revealed a bug in get_config_options about non-existing keys.
- added settings.pres_dir to ShowOffUtils::showoff_pdf_options
- fixed default value bug in ShowOffUtils::get_config_option
