### PR TITLE
allow test suite to run clean even in the absence of pdfkit and rmagick

### DIFF
--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -39,14 +39,16 @@ context "ShowOff basic tests" do
     assert_match '<div id="slides"', last_response.body
   end
 
-  test "can create a pdf version" do
-    get '/pdf'
-    assert last_response.ok?
+  if Object.const_defined? :PDFKit
+    test "can create a pdf version" do
+      get '/pdf'
+      assert last_response.ok?
 
-    pages = PDF::Inspector::Page.analyze(last_response.body).pages.size
-    assert_equal 2, pages
+      pages = PDF::Inspector::Page.analyze(last_response.body).pages.size
+      assert_equal 2, pages
 
-    assert last_response.body.size > 5000
+      assert last_response.body.size > 5000
+    end
   end
 
 end

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -44,7 +44,11 @@ context "ShowOff Utils tests" do
       content = File.read('static/index.html')
       assert_match 'My Presentation', content
       assert_equal 2, content.scan(/div class="slide"/).size
-      assert_match 'img src="./file/one/chacon.jpg" width="300" height="300" alt="chacon"', content
+      if Object.const_defined? :RMagick
+        assert_match 'img src="./file/one/chacon.jpg" width="300" height="300" alt="chacon"', content
+      else
+        assert_match 'img src="./file/one/chacon.jpg" alt="chacon"', content
+      end
     end
   end
 
@@ -57,7 +61,11 @@ context "ShowOff Utils tests" do
       content = `git cat-file -p gh-pages:index.html`
       assert_match 'My Presentation', content
       assert_equal 2, content.scan(/div class="slide"/).size
-      assert_match 'img src="./file/one/chacon.jpg" width="300" height="300" alt="chacon"', content
+      if Object.const_defined? :RMagick
+        assert_match 'img src="./file/one/chacon.jpg" width="300" height="300" alt="chacon"', content
+      else
+        assert_match 'img src="./file/one/chacon.jpg" alt="chacon"', content
+      end
     end
   end
 


### PR DESCRIPTION
looks like this was never pulled (even though you said it looked good before), so I'm submitting again, and this time I'm trying to be super-nice and make it from a newly-rebased branch
