### PR TITLE
Better Regexp for extracting urls from css files

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -446,7 +446,7 @@ class ShowOff < Sinatra::Application
         Dir.glob("#{pres_dir}/*.css").each do |css_path|
           File.open(css_path) do |file|
             data = file.read
-            data.scan(/url\((.*)\)/).flatten.each do |path|
+            data.scan(/url\("?(.*?)"?\)/).flatten.each do |path|
               logger.debug path
               dir = File.dirname(path)
               FileUtils.makedirs(File.join(file_dir, dir))

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -447,6 +447,8 @@ class ShowOff < Sinatra::Application
           File.open(css_path) do |file|
             data = file.read
             data.scan(/url\("?(.*?)"?\)/).flatten.each do |path|
+              path.gsub!(/(\#.*)$/, '') # get rid of the anchor
+              path.gsub!(/(\?.*)$/, '') # get rid of the query
               logger.debug path
               dir = File.dirname(path)
               FileUtils.makedirs(File.join(file_dir, dir))


### PR DESCRIPTION
Hi,

When I tried to generate a static version of my presentation, showoff failed to parse URLs in my CSS because they were surrounded by quotes:

``` css
src: url("style/fonts/proximanova-bold-proxima.eot")
```

So this is a fix to ignore quotes around urls.

Regards.
