### PR TITLE
Fixed GH issue #157 ArgumentError - invalid byte sequence in UTF-8

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -267,7 +267,7 @@ class ShowOff < Sinatra::Application
         sections.each do |section|
           if section =~ /^#/
             name = section.each_line.first.gsub(/^#*/,'').strip
-            data << process_markdown(name, "<!SLIDE subsection>\n" + section, static, pdf)
+            data << process_markdown(name, "<!SLIDE subsection>\n".force_encoding("UTF-8") + section, static, pdf)
           else
             files = []
             files << load_section_files(section)

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -259,6 +259,14 @@ class ShowOff < Sinatra::Application
       html.root.to_s
     end
 
+    def slide_subsection
+      if RUBY_VERSION >= "1.9"
+        "<!SLIDE subsection>\n".force_encoding("UTF-8") + section
+      else
+        "<!SLIDE subsection>\n" + section
+      end
+    end
+
     def get_slides_html(static=false, pdf=false)
       sections = ShowOffUtils.showoff_sections(settings.pres_dir, @logger)
       files = []
@@ -267,7 +275,7 @@ class ShowOff < Sinatra::Application
         sections.each do |section|
           if section =~ /^#/
             name = section.each_line.first.gsub(/^#*/,'').strip
-            data << process_markdown(name, "<!SLIDE subsection>\n".force_encoding("UTF-8") + section, static, pdf)
+            data << process_markdown(name, slide_subsection, static, pdf)
           else
             files = []
             files << load_section_files(section)

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -260,11 +260,7 @@ class ShowOff < Sinatra::Application
     end
 
     def slide_subsection
-      if RUBY_VERSION >= "1.9"
-        "<!SLIDE subsection>\n".force_encoding("UTF-8") + section
-      else
-        "<!SLIDE subsection>\n" + section
-      end
+      RUBY_VERSION >= "1.9" ? "<!SLIDE subsection>\n".force_encoding("UTF-8") : "<!SLIDE subsection>\n"
     end
 
     def get_slides_html(static=false, pdf=false)
@@ -275,7 +271,7 @@ class ShowOff < Sinatra::Application
         sections.each do |section|
           if section =~ /^#/
             name = section.each_line.first.gsub(/^#*/,'').strip
-            data << process_markdown(name, slide_subsection, static, pdf)
+            data << process_markdown(name, slide_subsection + section, static, pdf)
           else
             files = []
             files << load_section_files(section)


### PR DESCRIPTION
In Ruby 1.8 `String` was a collection of bytes, moving to 1.9 it's both the raw bytes and the attached Encoding information.

Works on Ruby 1.9.3-p0, Mac OS X Lion 10.7.2
