### PR TITLE
Skip copying paths from css files that reference external assets

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -447,6 +447,7 @@ class ShowOff < Sinatra::Application
           File.open(css_path) do |file|
             data = file.read
             data.scan(/url\((.*)\)/).flatten.each do |path|
+              next if path.match('^http')
               logger.debug path
               dir = File.dirname(path)
               FileUtils.makedirs(File.join(file_dir, dir))


### PR DESCRIPTION
(Allows the use of google fonts with @import)
