### PR TITLE
presenter view: give the spawned slides window the ability to move our location

### DIFF
--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -3,6 +3,10 @@ var w = null;
 
 $(function(){
 	w = window.open('/' + window.location.search);
+	// Give the slide window a handle to the presenter view window.
+	// This will let either window be made fullscreen and
+	// still process slide advance/rewinds correctly.
+	w.presenterView = window;
   // side menu accordian crap
 	$("#preso").bind("showoff:loaded", function (event) {
 		$(".menu > ul ul").hide()

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -215,7 +215,23 @@ function showSlide(back_step) {
   var currentContent = $(currentSlide).find(".content")
 	currentContent.trigger("showoff:show");
 
-	return getCurrentNotes()
+	var ret = getCurrentNotes()
+	// If we have a presenterView attribute, that means this window was
+	// opened by a presenter view, and we should poke it to make
+	// it be on the same slide as us and show the correct notes.
+        // 
+        // TODO: we do this in such a hacky way to avoid ever
+        // assigning to the presenterView variable here. If we do
+        // that, we can clobber the value sent in by the parent
+        // presentation view and break the feature. Is there a better
+        // way to do this?
+	if ('presenterView' in window) {
+                var pv = window.presenterView;
+		pv.slidenum = slidenum;
+		pv.showSlide(true);
+		pv.postSlide();
+	}
+	return ret;
 }
 
 function getSlideProgress()


### PR DESCRIPTION
This means that you can open the presenter view and have it spawn a
slides window, but then make the slides window fullscreen instead of
the presenter view (which can be a background window on another
display). I didn't test it very much, but it seems to work well enough.

I'm not terribly happy with how this looks, but it seemed like it might be desirable anyway.
