### PR TITLE
Avoid trying to load images from FS root.

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -275,7 +275,7 @@ class ShowOff < Sinatra::Application
     if defined?(Magick)
       def get_image_size(path)
         if !cached_image_size.key?(path)
-          img = Magick::Image.ping(File.join(@asset_path, path)).first
+          img = Magick::Image.ping(File.join(".", @asset_path, path)).first
           # don't set a size for svgs so they can expand to fit their container
           if img.mime_type == 'image/svg+xml'
             cached_image_size[path] = [nil, nil]


### PR DESCRIPTION
Without this change I get errors like:

```
Magick::ImageMagickError - unable to open file `/controllers/mvc.png' @ error/png.c/ReadPNGImage/3628:
/Users/mat/code/showoff/lib/showoff.rb:278:in `ping'
/Users/mat/code/showoff/lib/showoff.rb:278:in `get_image_size'
```
