### PR TITLE
Running under nginx+passenger throws an encoding error

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -36,6 +36,7 @@ class ShowOff < Sinatra::Application
   set :page_size, "Letter"
   set :pres_template, nil
   set :showoff_config, nil
+  set :encoding, nil
 
   def initialize(app=nil)
     super(app)
@@ -145,8 +146,11 @@ class ShowOff < Sinatra::Application
 
 
     def process_markdown(name, content, static=false, pdf=false)
+      if settings.encoding and content.respond_to?(:force_encoding)
+        content.force_encoding(settings.encoding)
+      end
+
       # if there are no !SLIDE markers, then make every H1 define a new slide
-      content.force_encoding('UTF-8') if content.respond_to?(:force_encoding)
       unless content =~ /^\<?!SLIDE/m
         content = content.gsub(/^# /m, "<!SLIDE>\n# ")
       end

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -62,7 +62,8 @@ class ShowOff < Sinatra::Application
       showoff_json = JSON.parse(File.read(ShowOffUtils.presentation_config_file))
       settings.showoff_config = showoff_json
       
-      # Set options for template and page size
+      # Set options for encoding, template and page size
+      settings.encoding = showoff_json["encoding"]
       settings.page_size = showoff_json["page-size"] || "Letter"
       settings.pres_template = showoff_json["templates"] 
     end

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -146,6 +146,7 @@ class ShowOff < Sinatra::Application
 
     def process_markdown(name, content, static=false, pdf=false)
       # if there are no !SLIDE markers, then make every H1 define a new slide
+      content.force_encoding('UTF-8') if content.respond_to?(:force_encoding)
       unless content =~ /^\<?!SLIDE/m
         content = content.gsub(/^# /m, "<!SLIDE>\n# ")
       end


### PR DESCRIPTION
If you try to serve a Showoff deck under nginx+passenger, you get this when trying to load the slides:

```
ArgumentError - invalid byte sequence in US-ASCII:
    /home/jcoglan/www/slides.jcoglan.com/app/vendor/showoff/lib/showoff.rb:149:in `process_markdown'
    /home/jcoglan/www/slides.jcoglan.com/app/vendor/showoff/lib/showoff.rb:356:in `block (2 levels) in get_slides_html'
    /home/jcoglan/www/slides.jcoglan.com/app/vendor/showoff/lib/showoff.rb:354:in `each'
    /home/jcoglan/www/slides.jcoglan.com/app/vendor/showoff/lib/showoff.rb:354:in `block in get_slides_html'
    /home/jcoglan/www/slides.jcoglan.com/app/vendor/showoff/lib/showoff.rb:345:in `each'
    /home/jcoglan/www/slides.jcoglan.com/app/vendor/showoff/lib/showoff.rb:345:in `get_slides_html'
    /home/jcoglan/www/slides.jcoglan.com/app/vendor/showoff/lib/showoff.rb:459:in `slides'
        ...
```

This patch forces the Markdown content to UTF-8 encoding to stop the error.
