### PR TITLE
Add ability to skip individual slides

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -166,6 +166,10 @@ definition, where tname is one of the following supported transitions:
 
 The transitions are provided by jQuery Cycle plugin. See http://www.malsup.com/jquery/cycle/browser.html to view the effects and http://www.malsup.com/jquery/cycle/adv2.html for how to add custom effects.
 
+Here's a list of other available keywords:
+
+* skip - Skips slides marked with this keyword
+
 You can manage the presentation with the following keys:
 
 * space, cursor right: next slide

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -143,6 +143,9 @@ class ShowOff < Sinatra::Application
       def empty?
         @text.strip == ""
       end
+      def skip?
+        @classes.include? 'skip'
+      end
     end
 
 
@@ -171,7 +174,7 @@ class ShowOff < Sinatra::Application
         end
       end
 
-      slides.delete_if {|slide| slide.empty? }
+      slides.delete_if {|slide| slide.empty? || slide.skip? }
 
       final = ''
       if slides.size > 1

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -24,6 +24,12 @@ context "ShowOff basic tests" do
     assert_match '<h1>My Presentation</h1>', last_response.body
   end
 
+  test "can skip slides" do
+    get '/slides'
+    assert last_response.ok?
+    assert_no_match /Skipped slide/, last_response.body
+  end
+
   test "can get asset list" do
     get '/assets_needed'
     assert last_response.ok?

--- a/test/fixtures/simple/one/01_slide.md
+++ b/test/fixtures/simple/one/01_slide.md
@@ -7,3 +7,9 @@
 * first point
 * second point
 * third point
+
+!SLIDE skip
+
+# Skipped slide
+
+This won't show up


### PR DESCRIPTION
Sometimes one wants to see how the presentation looks like without some slides (mostly when we are uncertain about keeping slide or not) but one don't want to delete them, here's an example:

```
!SLIDE bullets incremental transition=fade skip

# Bullet Points #

* first point
* second point
* third point
```

what do you think?
