### PR TITLE
Make it work with GLI 2.0

### DIFF
--- a/bin/showoff
+++ b/bin/showoff
@@ -186,4 +186,4 @@ on_error do |exception|
   true
 end
 
-exit GLI.run(ARGV)
+exit run(ARGV)


### PR DESCRIPTION
Small fix to make Showoff work with the newly-released GLI 2.0.
