### PR TITLE
Configure Markdown engine

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -150,6 +150,9 @@ class ShowOff < Sinatra::Application
       if settings.encoding and content.respond_to?(:force_encoding)
         content.force_encoding(settings.encoding)
       end
+      engine_options = ShowOffUtils.showoff_renderer_options(settings.pres_dir)
+      @logger.debug "renderer: #{Tilt[:markdown].name}"
+      @logger.debug "render options: #{engine_options.inspect}"
 
       # if there are no !SLIDE markers, then make every H1 define a new slide
       unless content =~ /^\<?!SLIDE/m
@@ -216,7 +219,7 @@ class ShowOff < Sinatra::Application
         else
           content += "<div class=\"#{content_classes.join(' ')}\" ref=\"#{name}\">\n"
         end
-        sl = Tilt[:markdown].new { slide.text }.render
+        sl = Tilt[:markdown].new(nil, nil, engine_options) { slide.text }.render
         sl = update_image_paths(name, sl, static, pdf)
         content += sl
         content += "</div>\n"

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -80,7 +80,7 @@ class ShowOff < Sinatra::Application
     @asset_path = "./"
 
     # Initialize Markdown Configuration
-    #MarkdownConfig::setup(settings.pres_dir)
+    MarkdownConfig::setup(settings.pres_dir)
   end
 
   def self.pres_dir_current

--- a/lib/showoff_utils.rb
+++ b/lib/showoff_utils.rb
@@ -316,7 +316,7 @@ class ShowOffUtils
 
   def self.showoff_renderer_options(dir = '.', default_options = {})
     opts = get_config_option(dir, showoff_markdown(dir))
-    Hash[opts.map {|k, v| [k.to_sym, v]}] # keys must be symbols
+    Hash[opts.map {|k, v| [k.to_sym, v]}] if opts    # keys must be symbols
   end
 
   def self.get_config_option(dir, option, default = nil)

--- a/lib/showoff_utils.rb
+++ b/lib/showoff_utils.rb
@@ -316,6 +316,7 @@ class ShowOffUtils
 
   def self.showoff_renderer_options(dir = '.', default_options = {})
     opts = get_config_option(dir, showoff_markdown(dir))
+    Hash[opts.map {|k, v| [k.to_sym, v]}] # keys must be symbols
   end
 
   def self.get_config_option(dir, option, default = nil)
@@ -413,17 +414,17 @@ module MarkdownConfig
 
       # Load maruku options
       opts = ShowOffUtils.showoff_renderer_options(dir_name,
-                                                   { 'use_tex' => false,
-                                                     'png_dir' => 'images',
-                                                     'html_png_url' => '/file/images/'})
+                                                   { :use_tex => false,
+                                                     :png_dir => 'images',
+                                                     :html_png_url => '/file/images/'})
 
-      if opts['use_tex']
+      if opts[:use_tex]
         MaRuKu::Globals[:html_math_output_mathml] = false
         MaRuKu::Globals[:html_math_engine] = 'none'
         MaRuKu::Globals[:html_math_output_png] = true
         MaRuKu::Globals[:html_png_engine] =  'blahtex'
-        MaRuKu::Globals[:html_png_dir] = opts['png_dir']
-        MaRuKu::Globals[:html_png_url] = opts['html_png_url']
+        MaRuKu::Globals[:html_png_dir] = opts[:png_dir]
+        MaRuKu::Globals[:html_png_url] = opts[:html_png_url]
       end
 
     when 'bluecloth'

--- a/lib/showoff_utils.rb
+++ b/lib/showoff_utils.rb
@@ -314,6 +314,10 @@ class ShowOffUtils
     get_config_option(dir, "markdown", "redcarpet")
   end
 
+  def self.showoff_renderer_options(dir = '.', default_options = {})
+    opts = get_config_option(dir, showoff_markdown(dir))
+  end
+
   def self.get_config_option(dir, option, default = nil)
     index = File.join(dir, ShowOffUtils.presentation_config_file)
     if File.exists?(index)
@@ -408,10 +412,10 @@ module MarkdownConfig
       require 'maruku/ext/math'
 
       # Load maruku options
-      opts = ShowOffUtils.get_config_option(dir_name, 'maruku',
-                                            { 'use_tex' => false,
-                                              'png_dir' => 'images',
-                                              'html_png_url' => '/file/images/'})
+      opts = ShowOffUtils.showoff_renderer_options(dir_name,
+                                                   { 'use_tex' => false,
+                                                     'png_dir' => 'images',
+                                                     'html_png_url' => '/file/images/'})
 
       if opts['use_tex']
         MaRuKu::Globals[:html_math_output_mathml] = false


### PR DESCRIPTION
The README says that [the Markdown rendering engine can be selected in the configuration file](https://github.com/schacon/showoff#markdown-engine), but the call to process this config option has been commented out in the current version. Going through the code and the commit that made the change, I cannot see why. So I reinstated it so that I could use Bluecloth/Discount, and it works fine. Except...

I wanted to change the default options that Bluecloth passes to Discount, and I figured that I could use the same mechanism as you used for configuring Maruku (adding a config key with the name of the Markdown engine).

However, Bluecloth expects the hash keys to be symbols, and I didn't see a way to generate those with the current JSON parser. But... I did find an suggestion for converting hash keys from strings to symbols, which seemed like a good way to go --- I can't think of a case where that wouldn't be as good or preferable. I updated the Maruku config code to use symbols instead, but I haven't got Maruku installed so I haven't tested that it still works.
