### PR TITLE
Parse rendered slide content as HTML instead of XML, to preserve HTML entities...

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -297,7 +297,7 @@ class ShowOff < Sinatra::Application
     end
 
     def update_commandline_code(slide)
-      html = Nokogiri::XML.parse(slide)
+      html = Nokogiri::HTML.fragment(slide)
       parser = CommandlineParser.new
 
       html.css('pre').each do |pre|
@@ -339,7 +339,7 @@ class ShowOff < Sinatra::Application
         end
         transform.apply(tree)
       end
-      html.root.to_s
+      html.to_html
     end
 
     def get_slides_html(static=false, pdf=false)


### PR DESCRIPTION
...which are removed by Nokogiri's XML parser. The existing code parses HTML as XML, so Nokogiri only recognizes XML's much smaller set of entities. To preserve HTML entities, parsing the text as an HTML fragment seems to work much better, and I have no encountered any issues with the change. (However, I have not been able to run the project tests --- they hang after the first test.)

I think there would be other cases where valid HTML would not be valid XML, so using the parser in XML mode does not seem appropriate here.
