### PR TITLE
The slideshow title is only being fetched if serving from current directory

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -407,7 +407,7 @@ class ShowOff < Sinatra::Application
 
     def index(static=false)
       if static
-        @title = ShowOffUtils.showoff_title
+        @title = ShowOffUtils.showoff_title(settings.pres_dir)
         @slides = get_slides_html(static)
 
         @pause_msg = ShowOffUtils.pause_msg
@@ -588,7 +588,7 @@ class ShowOff < Sinatra::Application
   end
 
   get %r{/(.*)} do
-    @title = ShowOffUtils.showoff_title
+    @title = ShowOffUtils.showoff_title(settings.pres_dir)
     @pause_msg = ShowOffUtils.pause_msg
     what = params[:captures].first
     what = 'index' if "" == what


### PR DESCRIPTION
Normally, the code passes the path to the slide show to the get-config methods in showoff_util.rb, but the two calls to get the slideshow title did not, so it would only work if the config file was in the current directory (the default value for the path argument).

I think this patch fixes the problem.
