### PR TITLE
Fix infinite loop and GLI-2 upgrade

### DIFF
--- a/bin/showoff
+++ b/bin/showoff
@@ -6,7 +6,7 @@ require 'showoff/version'
 require 'rubygems'
 require 'gli'
 
-include GLI
+include GLI::App
 
 version SHOWOFF_VERSION
 
@@ -186,4 +186,4 @@ on_error do |exception|
   true
 end
 
-exit GLI.run(ARGV)
+exit run(ARGV)

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -503,11 +503,7 @@ class ShowOff < Sinatra::Application
    def self.do_static(what)
       what = "index" if !what
 
-      # Nasty hack to get the actual ShowOff module
-      showoff = ShowOff.new
-      while !showoff.is_a?(ShowOff)
-        showoff = showoff.instance_variable_get(:@app)
-      end
+      showoff = ShowOff.new!
       name = showoff.instance_variable_get(:@pres_name)
       path = showoff.instance_variable_get(:@root_path)
       logger = showoff.instance_variable_get(:@logger)


### PR DESCRIPTION
Version 0.7.0 no longer works for me on OSX.  I have two issues:

1) GLI updates

This seems to have been discussed here.

https://github.com/schacon/showoff/pull/198
https://github.com/schacon/showoff/pull/193

2) Infinite loop

For me this loop never exists:

https://github.com/schacon/showoff/blob/ae11f6a3c82e96319ed6e37ea9ae092e9d871230/lib/showoff.rb#L509

I am not a ruby developer but this fix appeared to work:

http://stackoverflow.com/questions/12072865/calling-a-sinatra-app-instance-method-from-testcase
