### PR TITLE
Slight changes for GLI 2

### DIFF
--- a/bin/showoff
+++ b/bin/showoff
@@ -6,7 +6,7 @@ require 'showoff/version'
 require 'rubygems'
 require 'gli'
 
-include GLI
+include GLI::App
 
 version SHOWOFF_VERSION
 
@@ -186,4 +186,4 @@ on_error do |exception|
   true
 end
 
-exit GLI.run(ARGV)
+exit run(ARGV)

--- a/showoff.gemspec
+++ b/showoff.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency      "redcarpet"
   s.add_dependency      "nokogiri"
   s.add_dependency      "json"
-  s.add_dependency      "gli",">= 1.3.2"
+  s.add_dependency      "gli","~> 2"
   s.add_dependency      "parslet"
   s.add_development_dependency "mg"
   s.description       = <<-desc


### PR DESCRIPTION
When I gem install'ed showoff, I got GLI 2, even tho the gemspec specifies a 1.x version.  At any rate, I figured I'd update this executable, so now it should work with the latest GLI.
