### PR TITLE
presenter view: respect starting slide from URL

### DIFF
--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -2,7 +2,7 @@
 var w = null;
 
 $(function(){
-	w = window.open('/' + window.location.search);
+	w = window.open('/' + window.location.search + window.location.hash);
 
 	// Give the slide window a handle to the presenter view window.
 	// This will let either window be made fullscreen and


### PR DESCRIPTION
We didn't correctly pass the hash fragment of the location to the
spawned slides window, which caused the presenter view to always start
at slide 1, even if it was refreshed during slide development
someplace else in the slide deck. This corrects that defect.
